### PR TITLE
Fix three bugs: drain re-invoke, stale serverId on delete, household …

### DIFF
--- a/src/__tests__/db/items.test.ts
+++ b/src/__tests__/db/items.test.ts
@@ -1,0 +1,80 @@
+jest.mock('expo-sqlite', () => ({ openDatabaseAsync: jest.fn() }));
+jest.mock('expo-crypto', () => ({ randomUUID: jest.fn() }));
+
+import * as SQLite from 'expo-sqlite';
+import { randomUUID } from 'expo-crypto';
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  runAsync: jest.fn().mockResolvedValue(undefined),
+  getFirstAsync: jest.fn().mockResolvedValue({ version: 2 }),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+};
+
+// Prime the db cache once so that subsequent calls to getDb() skip migration
+// and don't consume getFirstAsync mock values.
+beforeAll(async () => {
+  (SQLite.openDatabaseAsync as jest.Mock).mockResolvedValue(mockDb);
+  const { getDb } = require('@/db/schema');
+  await getDb();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.execAsync.mockResolvedValue(undefined);
+  mockDb.runAsync.mockResolvedValue(undefined);
+  mockDb.getFirstAsync.mockResolvedValue({ version: 2 });
+  mockDb.getAllAsync.mockResolvedValue([]);
+  (SQLite.openDatabaseAsync as jest.Mock).mockResolvedValue(mockDb);
+  (randomUUID as jest.Mock).mockReturnValue('test-uuid');
+});
+
+const getModule = () => require('@/db/items');
+
+const baseRow = {
+  local_id: 'item-1',
+  server_id: 42,
+  list_local_id: 'list-1',
+  name: 'Milk',
+  description: '',
+  icon_key: 'milk',
+  category: 'Dairy',
+  is_checked: 0,
+  is_important: 0,
+  is_dirty: 0,
+  is_deleted: 0,
+  created_at: 1000,
+};
+
+describe('items', () => {
+  describe('getItem', () => {
+    it('returns null when item is not found', async () => {
+      const { getItem } = getModule();
+      // db is cached; getFirstAsync is called once for the actual query
+      mockDb.getFirstAsync.mockResolvedValueOnce(null);
+
+      const result = await getItem('missing-id');
+      expect(result).toBeNull();
+    });
+
+    it('returns the item with correct fields when found', async () => {
+      const { getItem } = getModule();
+      mockDb.getFirstAsync.mockResolvedValueOnce(baseRow);
+
+      const result = await getItem('item-1');
+      expect(result?.localId).toBe('item-1');
+      expect(result?.serverId).toBe(42);
+      expect(result?.name).toBe('Milk');
+      expect(result?.isDeleted).toBe(false);
+    });
+
+    it('returns the item even when soft-deleted (no is_deleted filter)', async () => {
+      const { getItem } = getModule();
+      mockDb.getFirstAsync.mockResolvedValueOnce({ ...baseRow, is_deleted: 1, server_id: 55 });
+
+      const result = await getItem('item-1');
+      expect(result?.isDeleted).toBe(true);
+      expect(result?.serverId).toBe(55);
+    });
+  });
+});

--- a/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
+++ b/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
@@ -48,13 +48,25 @@ describe('HouseholdPickerScreen', () => {
     expect(getByTestId('household-loading')).toBeTruthy();
   });
 
-  it('auto-selects when only one household and no selection yet', async () => {
+  it('auto-selects when only one household during onboarding (canGoBack = false)', async () => {
     const household = makeHousehold();
     (getHouseholds as jest.Mock).mockResolvedValue([household]);
 
     render(<HouseholdPickerScreen {...baseProps} />);
 
     await waitFor(() => expect(mockSelectHousehold).toHaveBeenCalledWith(household));
+  });
+
+  it('does not auto-select when only one household and reached from nav bar (canGoBack = true)', async () => {
+    mockNavigation.canGoBack.mockReturnValue(true);
+    mockStore(makeHousehold());
+    const household = makeHousehold();
+    (getHouseholds as jest.Mock).mockResolvedValue([household]);
+
+    const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
+
+    await waitFor(() => expect(getByText('Home')).toBeTruthy());
+    expect(mockSelectHousehold).not.toHaveBeenCalled();
   });
 
   it('renders list of households', async () => {

--- a/src/__tests__/sync/syncManager.test.ts
+++ b/src/__tests__/sync/syncManager.test.ts
@@ -202,4 +202,25 @@ describe('drain()', () => {
     expect(syncQueue.remove).toHaveBeenCalledWith('op-1');
     expect(api.addItemByName).not.toHaveBeenCalled();
   });
+
+  it('resets draining flag after completion so a follow-up drain processes remaining ops', async () => {
+    // Simulates the case where ops were enqueued concurrently during a drain.
+    // After the first drain completes (with remaining ops in the queue), `draining`
+    // must be reset to false so the internally re-invoked drain (or any caller) can
+    // pick up the remaining ops immediately.
+    const op = makeAddOp();
+    const op2 = makeAddOp({ id: 'op-2' });
+    (syncQueue.getAll as jest.Mock)
+      .mockResolvedValueOnce([op])   // first drain: initial read
+      .mockResolvedValueOnce([op2])  // first drain: finally remaining (re-drain triggered)
+      .mockResolvedValueOnce([op2])  // second drain: initial read
+      .mockResolvedValue([]);         // second drain: finally remaining
+    (api.addItemByName as jest.Mock).mockResolvedValue({ id: 99 });
+
+    await drain();
+    // Verify draining flag was reset: a second explicit drain runs successfully.
+    await drain();
+
+    expect(api.addItemByName).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/db/items.ts
+++ b/src/db/items.ts
@@ -49,6 +49,15 @@ function rowToItem(row: ItemRow): LocalItem {
   };
 }
 
+export async function getItem(localId: string): Promise<LocalItem | null> {
+  const db = await getDb();
+  const row = await db.getFirstAsync<ItemRow>(
+    'SELECT * FROM local_items WHERE local_id = ?',
+    [localId]
+  );
+  return row ? rowToItem(row) : null;
+}
+
 export async function getItemsForList(listLocalId: string): Promise<LocalItem[]> {
   const db = await getDb();
   const rows = await db.getAllAsync<ItemRow>(

--- a/src/screens/households/HouseholdPickerScreen.tsx
+++ b/src/screens/households/HouseholdPickerScreen.tsx
@@ -34,9 +34,11 @@ export default function HouseholdPickerScreen({ navigation }: HouseholdPickerScr
           setError('No households found on this server.');
           return;
         }
-        // During onboarding with a single household, auto-select and let the
-        // navigator transition automatically (no explicit navigation needed).
-        if (results.length === 1 && selectedHousehold === null) {
+        // During onboarding (no back stack) with a single household, auto-select
+        // and let the navigator transition to ListDetail automatically.
+        // When reached from the nav bar (canGoBack = true), always show the list
+        // so the user can explicitly confirm or switch their household.
+        if (results.length === 1 && !canGoBack) {
           selectHousehold(results[0]);
           return;
         }

--- a/src/screens/lists/ListDetailScreen.tsx
+++ b/src/screens/lists/ListDetailScreen.tsx
@@ -183,15 +183,17 @@ export default function ListDetailScreen({ navigation }: ListDetailScreenProps) 
   }, [items]);
 
   const handleDelete = useCallback(async (localId: string) => {
-    const item = items.find((i) => i.localId === localId);
-    if (!item) return;
+    // Soft-delete first, then read fresh from DB — state.serverId may be stale
+    // if markItemSynced ran asynchronously since the item was added to state.
     await itemsDb.softDeleteItem(localId);
-    if (item.serverId !== null && activeServerId !== null && activeLocalId !== null) {
+    const freshItem = await itemsDb.getItem(localId);
+    if (freshItem?.serverId !== null && freshItem?.serverId !== undefined
+        && activeServerId !== null && activeLocalId !== null) {
       await syncManager.enqueue(
         {
           opType: 'REMOVE_ITEM',
           listServerId: activeServerId,
-          itemServerId: item.serverId,
+          itemServerId: freshItem.serverId,
           itemLocalId: localId,
         },
         activeLocalId
@@ -200,7 +202,7 @@ export default function ListDetailScreen({ navigation }: ListDetailScreenProps) 
       await itemsDb.hardDeleteItem(localId);
     }
     setItems((prev) => prev.filter((i) => i.localId !== localId));
-  }, [items, activeLocalId, activeServerId]);
+  }, [activeLocalId, activeServerId]);
 
   const handleSave = useCallback(async (localId: string, name: string, iconKey: string | null) => {
     const item = items.find((i) => i.localId === localId);

--- a/src/sync/syncManager.ts
+++ b/src/sync/syncManager.ts
@@ -24,6 +24,8 @@ export async function drain(): Promise<void> {
   const store = useSyncStore.getState();
   store.setStatus('syncing');
 
+  let failedDuringDrain = false;
+
   try {
     const ops = await syncQueue.getAll();
     store.setPendingCount(ops.length);
@@ -48,6 +50,7 @@ export async function drain(): Promise<void> {
           await syncQueue.incrementAttempts(op.id);
           const delay = SYNC_BACKOFF_MS[Math.min(op.attempts, SYNC_BACKOFF_MS.length - 1)];
           scheduleRetry(delay);
+          failedDuringDrain = true;
           break;
         }
       }
@@ -57,6 +60,9 @@ export async function drain(): Promise<void> {
     const remaining = (await syncQueue.getAll()).length;
     useSyncStore.getState().setPendingCount(remaining);
     useSyncStore.getState().setStatus(remaining > 0 ? 'error' : 'idle');
+    // Re-drain if ops were concurrently enqueued while this pass was running.
+    // Don't re-drain immediately after a failure — scheduleRetry handles backoff.
+    if (remaining > 0 && !failedDuringDrain) void drain();
   }
 }
 


### PR DESCRIPTION
…auto-select

**Drain re-invoke (yellow pending sync stays visible)** drain() now tracks failedDuringDrain. If the pass completed successfully but remaining ops exist (enqueued concurrently while drain was running), it calls void drain() again from the finally block so those ops aren't left stranded.

**Stale serverId on delete (delete not syncing)**
handleDelete was reading item.serverId from React state, which stays null for newly-added items even after markItemSynced updates the DB asynchronously. Fixed by reading the item fresh from DB (new getItem(localId) helper) after softDeleteItem so it always sees the real serverId.

**Household auto-select when navigating from nav bar** The single-household auto-select now checks !canGoBack instead of selectedHousehold === null. In onboarding (canGoBack = false) single households still auto-select; in-app (canGoBack = true) the list is always shown so users can explicitly confirm or switch.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh