### PR TITLE
Fix item update 400: send complete object with explicit nulls

### DIFF
--- a/src/__tests__/sync/syncManager.test.ts
+++ b/src/__tests__/sync/syncManager.test.ts
@@ -180,6 +180,7 @@ describe('drain()', () => {
         itemServerId: 12,
         itemLocalId: 'item-local-1',
         name: 'Almond Milk',
+        description: '2 bunches',
         iconKey: 'milk_carton',
         category: { id: 9, name: '🥛 Dairy', ordering: 0 },
       },
@@ -191,7 +192,7 @@ describe('drain()', () => {
 
     await drain();
 
-    expect(api.updateItem).toHaveBeenCalledWith(12, 'Almond Milk', 'milk_carton', { id: 9, name: '🥛 Dairy', ordering: 0 });
+    expect(api.updateItem).toHaveBeenCalledWith(12, 'Almond Milk', '2 bunches', 'milk_carton', { id: 9, name: '🥛 Dairy', ordering: 0 });
     expect(syncQueue.remove).toHaveBeenCalledWith('op-upd');
   });
 

--- a/src/api/shoppinglists.ts
+++ b/src/api/shoppinglists.ts
@@ -84,14 +84,23 @@ export async function updateItemDescription(
 export async function updateItem(
   itemId: number,
   name: string,
+  description: string,
   iconKey: string | null,
   category: { id: number; name: string; ordering: number } | null
 ): Promise<void> {
   const client = getApiClient();
-  const body: Record<string, unknown> = { name };
-  if (iconKey !== null) body.icon = iconKey;
-  if (category !== null) body.category = category;
-  await client.post(`/item/${itemId}`, body);
+  await client.post(`/item/${itemId}`, {
+    id: itemId,
+    name,
+    description,
+    icon: iconKey,
+    category,
+    ordering: 0,
+    default: false,
+    default_key: null,
+    created_at: null,
+    created_by: null,
+  });
 }
 
 export async function createShoppingList(name: string, householdId: number): Promise<ApiShoppingList> {

--- a/src/db/syncQueue.ts
+++ b/src/db/syncQueue.ts
@@ -43,6 +43,7 @@ export const UpdateItemPayloadSchema = z.object({
   itemServerId: z.number(),
   itemLocalId: z.string(),
   name: z.string(),
+  description: z.string(),
   iconKey: z.string().nullable(),
   category: ServerCategorySchema.nullable(),
 });

--- a/src/screens/lists/ListDetailScreen.tsx
+++ b/src/screens/lists/ListDetailScreen.tsx
@@ -238,6 +238,7 @@ export default function ListDetailScreen({ navigation }: ListDetailScreenProps) 
           itemServerId: freshItem.serverId,
           itemLocalId: localId,
           name,
+          description: freshItem.description,
           iconKey,
           category,
         },

--- a/src/sync/syncManager.ts
+++ b/src/sync/syncManager.ts
@@ -128,6 +128,7 @@ async function dispatchPayload(payload: SyncPayload): Promise<void> {
       await api.updateItem(
         payload.itemServerId,
         payload.name,
+        payload.description,
         payload.iconKey,
         payload.category
       );


### PR DESCRIPTION
POST /item/{id} requires a full item-shaped payload. Send all required fields including id, description, ordering, default, default_key, created_at, created_by — with nulls explicit rather than omitted.

Add description to UpdateItemPayload so the existing per-list description is preserved rather than blanked on update.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh