### PR TITLE
feat: Done button on HouseholdPickerScreen during onboarding

### DIFF
--- a/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
+++ b/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
@@ -87,46 +87,113 @@ describe('HouseholdPickerScreen', () => {
     });
   });
 
-  it('calls persistAndSelectHousehold when a household is tapped', async () => {
-    const household = makeHousehold({ id: 2, name: 'Office' });
-    mockGetHouseholds.mockResolvedValue([
-      makeHousehold({ id: 1, name: 'Home' }),
-      household,
-    ]);
+  describe('in-app mode (canGoBack = true)', () => {
+    beforeEach(() => {
+      mockNavigation.canGoBack.mockReturnValue(true);
+    });
 
-    const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
-    await waitFor(() => expect(getByText('Office')).toBeTruthy());
+    it('calls persistAndSelectHousehold immediately when a household is tapped', async () => {
+      const household = makeHousehold({ id: 2, name: 'Office' });
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        household,
+      ]);
 
-    fireEvent.press(getByText('Office'));
-    await waitFor(() => expect(mockPersistAndSelectHousehold).toHaveBeenCalledWith(household));
+      const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByText('Office')).toBeTruthy());
+
+      fireEvent.press(getByText('Office'));
+      await waitFor(() => expect(mockPersistAndSelectHousehold).toHaveBeenCalledWith(household));
+    });
+
+    it('calls goBack after selecting', async () => {
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
+
+      const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByText('Office')).toBeTruthy());
+
+      fireEvent.press(getByText('Office'));
+      await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalled());
+    });
+
+    it('does not show Done button', async () => {
+      mockGetHouseholds.mockResolvedValue([makeHousehold()]);
+
+      const { queryByTestId } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(queryByTestId('done-button')).toBeNull());
+    });
   });
 
-  it('calls goBack after selecting when canGoBack is true', async () => {
-    mockNavigation.canGoBack.mockReturnValue(true);
-    mockGetHouseholds.mockResolvedValue([
-      makeHousehold({ id: 1, name: 'Home' }),
-      makeHousehold({ id: 2, name: 'Office' }),
-    ]);
+  describe('onboarding mode (canGoBack = false)', () => {
+    it('does not call persistAndSelectHousehold when a household is tapped', async () => {
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
 
-    const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
-    await waitFor(() => expect(getByText('Office')).toBeTruthy());
+      const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByText('Office')).toBeTruthy());
 
-    fireEvent.press(getByText('Office'));
-    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalled());
-  });
+      fireEvent.press(getByText('Office'));
+      expect(mockPersistAndSelectHousehold).not.toHaveBeenCalled();
+    });
 
-  it('does not call goBack during onboarding (canGoBack false)', async () => {
-    mockNavigation.canGoBack.mockReturnValue(false);
-    mockGetHouseholds.mockResolvedValue([
-      makeHousehold({ id: 1, name: 'Home' }),
-      makeHousehold({ id: 2, name: 'Office' }),
-    ]);
+    it('does not call goBack when a household is tapped', async () => {
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
 
-    const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
-    await waitFor(() => expect(getByText('Office')).toBeTruthy());
+      const { getByText } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByText('Office')).toBeTruthy());
 
-    fireEvent.press(getByText('Office'));
-    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+      fireEvent.press(getByText('Office'));
+      expect(mockNavigation.goBack).not.toHaveBeenCalled();
+    });
+
+    it('shows Done button when no household is pre-selected (disabled)', async () => {
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
+
+      const { getByTestId } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByTestId('done-button')).toBeTruthy());
+    });
+
+    it('Done button calls persistAndSelectHousehold with the selected household', async () => {
+      const office = makeHousehold({ id: 2, name: 'Office' });
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        office,
+      ]);
+
+      const { getByText, getByTestId } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByText('Office')).toBeTruthy());
+
+      fireEvent.press(getByText('Office'));
+      fireEvent.press(getByTestId('done-button'));
+
+      await waitFor(() =>
+        expect(mockPersistAndSelectHousehold).toHaveBeenCalledWith(office)
+      );
+    });
+
+    it('Done button does not call persistAndSelectHousehold when no household selected', async () => {
+      mockGetHouseholds.mockResolvedValue([
+        makeHousehold({ id: 1, name: 'Home' }),
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
+
+      const { getByTestId } = render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(getByTestId('done-button')).toBeTruthy());
+
+      fireEvent.press(getByTestId('done-button'));
+      expect(mockPersistAndSelectHousehold).not.toHaveBeenCalled();
+    });
   });
 
   it('shows error message when API fails', async () => {

--- a/src/screens/households/HouseholdPickerScreen.tsx
+++ b/src/screens/households/HouseholdPickerScreen.tsx
@@ -169,12 +169,20 @@ export default function HouseholdPickerScreen({ navigation }: HouseholdPickerScr
 
   async function handleSelect(household: Household) {
     setSelectedId(household.id);
-    await persistAndSelectHousehold(household);
-    // In-app mode: go back to the list. In onboarding mode, the conditional
+    // In-app mode: persist immediately and go back.
+    // In onboarding mode: the Done button handles persist; the conditional
     // render in RootNavigator transitions to ListDetail automatically.
     if (canGoBack) {
+      await persistAndSelectHousehold(household);
       navigation.goBack();
     }
+  }
+
+  async function handleDone() {
+    const household = households.find((h) => h.id === selectedId);
+    if (!household) return;
+    await persistAndSelectHousehold(household);
+    // MainNavigator auto-transitions when selectedHousehold becomes non-null.
   }
 
   return (
@@ -190,7 +198,22 @@ export default function HouseholdPickerScreen({ navigation }: HouseholdPickerScr
             <Text style={styles.backText}>‹ Back</Text>
           </TouchableOpacity>
         )}
-        <Text style={styles.title}>Households</Text>
+        <View style={styles.titleRow}>
+          <Text style={styles.title}>Households</Text>
+          {!canGoBack && (
+            <TouchableOpacity
+              style={styles.doneBtn}
+              onPress={handleDone}
+              disabled={selectedId === null}
+              activeOpacity={0.7}
+              testID="done-button"
+            >
+              <Text style={[styles.doneText, selectedId === null && styles.doneTextDisabled]}>
+                Done
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       {loading ? (
@@ -236,11 +259,28 @@ const styles = StyleSheet.create({
     color: Colors.mint,
     fontWeight: '600',
   },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
   title: {
     fontSize: FontSize.title,
     fontWeight: '900',
     color: Colors.mint,
     letterSpacing: -0.5,
+  },
+  doneBtn: {
+    paddingVertical: 4,
+    paddingLeft: Spacing.md,
+  },
+  doneText: {
+    fontSize: FontSize.body,
+    color: Colors.mint,
+    fontWeight: '700',
+  },
+  doneTextDisabled: {
+    color: Colors.mintLight,
   },
   center: {
     flex: 1,


### PR DESCRIPTION
During onboarding (canGoBack = false, multiple households) tapping a row now only highlights the selection — it no longer immediately persists. A "Done" button appears in the header (top-right, enabled once a household is selected) and calls persistAndSelectHousehold, after which MainNavigator auto-transitions to ListDetail.

In-app mode (canGoBack = true) is unchanged: tap → persist → goBack.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh