### PR TITLE
feat: move delete action from long left swipe to long right swipe

### DIFF
--- a/src/__tests__/components/SwipeableItem.test.tsx
+++ b/src/__tests__/components/SwipeableItem.test.tsx
@@ -191,8 +191,8 @@ describe('SwipeableItem', () => {
     });
   });
 
-  describe('swipe left — long (delete)', () => {
-    it('calls onDelete when released past DELETE threshold', () => {
+  describe('swipe left — long (delete removed)', () => {
+    it('does not call onDelete when swiped far left', () => {
       const handlers = makeHandlers();
       render(<SwipeableItem item={makeItem()} {...handlers} />);
 
@@ -200,12 +200,11 @@ describe('SwipeableItem', () => {
         gestureCbs.onEnd?.({ translationX: -185, velocityX: 0 });
       });
 
-      expect(handlers.onDelete).toHaveBeenCalledWith('item-1');
-      expect(handlers.onToggleDone).not.toHaveBeenCalled();
+      expect(handlers.onDelete).not.toHaveBeenCalled();
     });
   });
 
-  describe('swipe right — important', () => {
+  describe('swipe right — important (short)', () => {
     it('calls onToggleImportant when released past STAR threshold', () => {
       const handlers = makeHandlers();
       render(<SwipeableItem item={makeItem()} {...handlers} />);
@@ -229,6 +228,32 @@ describe('SwipeableItem', () => {
     });
   });
 
+  describe('swipe right — long (delete)', () => {
+    it('calls onDelete when released past DELETE threshold', () => {
+      const handlers = makeHandlers();
+      render(<SwipeableItem item={makeItem()} {...handlers} />);
+
+      act(() => {
+        gestureCbs.onEnd?.({ translationX: 115, velocityX: 0 });
+      });
+
+      expect(handlers.onDelete).toHaveBeenCalledWith('item-1');
+      expect(handlers.onToggleImportant).not.toHaveBeenCalled();
+    });
+
+    it('does not call onDelete when released between star and delete thresholds', () => {
+      const handlers = makeHandlers();
+      render(<SwipeableItem item={makeItem()} {...handlers} />);
+
+      act(() => {
+        gestureCbs.onEnd?.({ translationX: 60, velocityX: 0 });
+      });
+
+      expect(handlers.onDelete).not.toHaveBeenCalled();
+      expect(handlers.onToggleImportant).toHaveBeenCalledWith('item-1');
+    });
+  });
+
   describe('back zone visual state', () => {
     it('transitions through zones as swipe value changes', () => {
       render(<SwipeableItem item={makeItem()} {...makeHandlers()} />);
@@ -238,8 +263,8 @@ describe('SwipeableItem', () => {
         gestureCbs.onUpdate?.({ translationX: 0 });
         gestureCbs.onUpdate?.({ translationX: -40 });
         gestureCbs.onUpdate?.({ translationX: -80 });
-        gestureCbs.onUpdate?.({ translationX: -185 });
         gestureCbs.onUpdate?.({ translationX: 40 });
+        gestureCbs.onUpdate?.({ translationX: 115 });
       });
     });
   });

--- a/src/components/SwipeableItem.tsx
+++ b/src/components/SwipeableItem.tsx
@@ -2,9 +2,9 @@
  * SwipeableItem — shopping list row with gesture-based actions.
  *
  * Gestures (all spring back to resting after release):
- *   Swipe left ≥ 72px   → toggle done
- *   Swipe left ≥ 180px  → delete
- *   Swipe right ≥ 36px  → toggle important
+ *   Swipe left ≥ 36px   → toggle done
+ *   Swipe right ≥ 36px  → toggle important (or undo if item is checked)
+ *   Swipe right ≥ 108px → delete
  *   Double-tap card      → enter edit mode
  *   Tap check button     → toggle done
  *
@@ -41,8 +41,8 @@ const SWIPE_STAR_PX = 36;
 const DOUBLE_TAP_MS = 280;
 
 // Maximum card travel distances (clamped in onUpdate).
-const LEFT_TRAVEL_MAX = 162;
-const RIGHT_TRAVEL_MAX = 108;
+const LEFT_TRAVEL_MAX = 72;
+const RIGHT_TRAVEL_MAX = 162;
 
 const SPRING = { damping: 20, stiffness: 200 } as const;
 
@@ -292,26 +292,26 @@ function SwipeRowContent({
       translateX.value = x;
 
       const zone =
-        x < -SWIPE_DELETE_PX ? 2
-        : x < -SWIPE_DONE_PX ? 1
-        : x > SWIPE_STAR_PX  ? 3
+        x < -SWIPE_DONE_PX    ? 1  // done
+        : x > SWIPE_DELETE_PX ? 3  // delete (right long)
+        : x > SWIPE_STAR_PX   ? 2  // star / undo (right short)
         : 0;
 
       if (zone !== currentZone.value) {
         currentZone.value = zone;
         const name: BackZone =
-          zone === 1 ? 'done' : zone === 2 ? 'delete' : zone === 3 ? 'star' : 'none';
+          zone === 1 ? 'done' : zone === 2 ? 'star' : zone === 3 ? 'delete' : 'none';
         runOnJS(updateZone)(name);
       }
     })
     .onEnd((e) => {
-      if (e.translationX < -SWIPE_DELETE_PX) {
-        runOnJS(onDelete)();
-      } else if (e.translationX < -SWIPE_DONE_PX) {
+      if (e.translationX < -SWIPE_DONE_PX) {
         runOnJS(onToggleDone)();
+      } else if (e.translationX > SWIPE_DELETE_PX) {
+        runOnJS(onDelete)();
       } else if (e.translationX > SWIPE_STAR_PX) {
-        // Checked (trolley) items: right-swipe = undo back to list.
-        // Unchecked items: right-swipe = toggle important.
+        // Checked (trolley) items: right-swipe short = undo back to list.
+        // Unchecked items: right-swipe short = toggle important.
         if (item.isChecked) {
           runOnJS(onToggleDone)();
         } else {
@@ -333,9 +333,9 @@ function SwipeRowContent({
   const backStyle = useAnimatedStyle(() => {
     const x = translateX.value;
     const bg =
-      x < -SWIPE_DELETE_PX ? Colors.deleteRed
-      : x < -SWIPE_DONE_PX ? (item.isChecked ? '#ffe8cc' : Colors.mintLight)
-      : x > SWIPE_STAR_PX  ? (item.isChecked ? '#ffe8cc' : '#fffae8')
+      x < -SWIPE_DONE_PX    ? (item.isChecked ? '#ffe8cc' : Colors.mintLight)
+      : x > SWIPE_DELETE_PX ? Colors.deleteRed
+      : x > SWIPE_STAR_PX   ? (item.isChecked ? '#ffe8cc' : '#fffae8')
       : 'transparent';
     return { backgroundColor: bg };
   });
@@ -360,25 +360,25 @@ function SwipeRowContent({
       <Animated.View
         style={[StyleSheet.absoluteFill, backStyles.container, backStyle]}
       >
-        {backZone === 'star' && (
+        {(backZone === 'star' || backZone === 'delete') && (
           <View style={backStyles.leftZone}>
-            {item.isChecked
-              ? <IconUndo color={Colors.mint} size={24} />
-              : <IconStar color={Colors.yellow} size={24} filled={item.isImportant} />
-            }
-          </View>
-        )}
-        {(backZone === 'done' || backZone === 'delete') && (
-          <View style={backStyles.rightZone}>
             {backZone === 'delete' && (
               <IconTrash color={Colors.deleteRedStrong} size={24} />
             )}
-            {backZone === 'done' && item.isChecked && (
+            {backZone === 'star' && item.isChecked && (
               <IconUndo color={Colors.mint} size={24} />
             )}
-            {backZone === 'done' && !item.isChecked && (
-              <IconCheck color={Colors.mint} size={24} />
+            {backZone === 'star' && !item.isChecked && (
+              <IconStar color={Colors.yellow} size={24} filled={item.isImportant} />
             )}
+          </View>
+        )}
+        {backZone === 'done' && (
+          <View style={backStyles.rightZone}>
+            {item.isChecked
+              ? <IconUndo color={Colors.mint} size={24} />
+              : <IconCheck color={Colors.mint} size={24} />
+            }
           </View>
         )}
       </Animated.View>


### PR DESCRIPTION
Gesture map after this change:
  Swipe left  ≥ 36px  → toggle done (check / uncheck)
  Swipe right ≥ 36px  → toggle important, or undo if item is checked
  Swipe right ≥ 108px → delete  (was: swipe left ≥ 108px)

Trash icon now appears in the left reveal zone (right swipe). LEFT_TRAVEL_MAX reduced to 72 (one action only); RIGHT_TRAVEL_MAX increased to 162 to give comfortable overshoot past the delete threshold.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh