### PR TITLE
fix: explicitly navigate to ListDetail after household is selected in onboarding

### DIFF
--- a/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
+++ b/src/__tests__/screens/households/HouseholdPickerScreen.test.tsx
@@ -25,7 +25,7 @@ import { useHouseholdStore, persistAndSelectHousehold } from '@/store/householdS
 import type { Household } from '@/api/households';
 
 const mockPersistAndSelectHousehold = persistAndSelectHousehold as unknown as jest.Mock;
-const mockNavigation = { navigate: jest.fn(), canGoBack: jest.fn(), goBack: jest.fn() };
+const mockNavigation = { navigate: jest.fn(), canGoBack: jest.fn(), goBack: jest.fn(), reset: jest.fn() };
 const baseProps = { navigation: mockNavigation as never, route: {} as never };
 
 function makeHousehold(overrides: Partial<Household> = {}): Household {
@@ -193,6 +193,36 @@ describe('HouseholdPickerScreen', () => {
 
       fireEvent.press(getByTestId('done-button'));
       expect(mockPersistAndSelectHousehold).not.toHaveBeenCalled();
+    });
+
+    it('resets navigation to ListDetail when selectedHousehold becomes non-null', async () => {
+      const household = makeHousehold();
+      mockGetHouseholds.mockResolvedValue([
+        household,
+        makeHousehold({ id: 2, name: 'Office' }),
+      ]);
+
+      // Start with no selection, then simulate store updating after Done.
+      const { rerender } = render(<HouseholdPickerScreen {...baseProps} />);
+      mockStore(household);
+      rerender(<HouseholdPickerScreen {...baseProps} />);
+
+      await waitFor(() =>
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [{ name: 'ListDetail' }],
+        })
+      );
+    });
+
+    it('does not reset navigation when canGoBack is true and selectedHousehold is set', async () => {
+      mockNavigation.canGoBack.mockReturnValue(true);
+      mockStore(makeHousehold());
+      mockGetHouseholds.mockResolvedValue([makeHousehold()]);
+
+      render(<HouseholdPickerScreen {...baseProps} />);
+      await waitFor(() => expect(mockNavigation.goBack).not.toHaveBeenCalled());
+      expect(mockNavigation.reset).not.toHaveBeenCalled();
     });
   });
 

--- a/src/screens/households/HouseholdPickerScreen.tsx
+++ b/src/screens/households/HouseholdPickerScreen.tsx
@@ -136,6 +136,16 @@ export default function HouseholdPickerScreen({ navigation }: HouseholdPickerScr
 
   const canGoBack = navigation.canGoBack();
 
+  // HouseholdPicker lives in both the null and non-null selectedHousehold
+  // branches of MainNavigator, so React Navigation won't auto-transition when
+  // the store changes. Explicitly reset to ListDetail once a household is
+  // persisted (covers both the Done button and single-household auto-select).
+  useEffect(() => {
+    if (!canGoBack && selectedHousehold !== null) {
+      navigation.reset({ index: 0, routes: [{ name: 'ListDetail' }] });
+    }
+  }, [selectedHousehold, canGoBack, navigation]);
+
   useEffect(() => {
     async function load() {
       try {


### PR DESCRIPTION
HouseholdPicker is registered in both branches of MainNavigator (null and non-null selectedHousehold), so React Navigation does not auto-transition when selectedHousehold changes — it keeps the current screen active.

Add a useEffect that calls navigation.reset() to ListDetail as soon as selectedHousehold becomes non-null while in onboarding mode (canGoBack=false). This fixes both the Done button path and the single-household auto-select path.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh