### PR TITLE
feat: use exact-matched suggestion instead of add-as-typed row

### DIFF
--- a/src/__tests__/components/AddItemBar.test.tsx
+++ b/src/__tests__/components/AddItemBar.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for AddItemBar.
+ * useItemSuggestions is mocked so tests remain synchronous.
+ */
+
+jest.mock('@/hooks/useItemSuggestions', () => ({
+  useItemSuggestions: jest.fn(() => []),
+}));
+
+jest.mock('@/components/KitchenOwlIcon', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  function KitchenOwlIcon() { return React.createElement(View, null); }
+  return KitchenOwlIcon;
+});
+
+jest.mock('@/components/icons/CameraIcon', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  function CameraIcon() { return React.createElement(View, null); }
+  return CameraIcon;
+});
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import AddItemBar from '@/components/AddItemBar';
+import { useItemSuggestions } from '@/hooks/useItemSuggestions';
+
+const milkSuggestion = {
+  key: 'server:milk',
+  displayName: 'milk',
+  iconKey: 'milk',
+  category: 'Dairy',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useItemSuggestions as jest.Mock).mockReturnValue([]);
+});
+
+describe('AddItemBar', () => {
+  describe('add-as-typed row', () => {
+    it('shows the typed row when there are no suggestions', () => {
+      const onAdd = jest.fn();
+      const { queryByText } = render(<AddItemBar onAdd={onAdd} />);
+      // No input yet — suggestions panel is hidden entirely
+      expect(queryByText('+')).toBeNull();
+    });
+
+    it('shows the typed row when no suggestion exactly matches the input', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([
+        { key: 'server:milkshake', displayName: 'milkshake', iconKey: null, category: 'Dairy' },
+      ]);
+      const { getByTestId, queryByText } = render(<AddItemBar onAdd={jest.fn()} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'milk');
+      // typed row arrow is rendered
+      expect(queryByText('→')).toBeTruthy();
+    });
+
+    it('hides the typed row when a suggestion is an exact (case-insensitive) match', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([milkSuggestion]);
+      const { getByTestId, queryByText } = render(<AddItemBar onAdd={jest.fn()} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'milk');
+      expect(queryByText('→')).toBeNull();
+    });
+
+    it('hides the typed row for a case-insensitive match', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([milkSuggestion]);
+      const { getByTestId, queryByText } = render(<AddItemBar onAdd={jest.fn()} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'Milk');
+      expect(queryByText('→')).toBeNull();
+    });
+  });
+
+  describe('handleAdd', () => {
+    it('submits raw typed value with no iconKey when no exact match', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([
+        { key: 'server:milkshake', displayName: 'milkshake', iconKey: null, category: 'Dairy' },
+      ]);
+      const onAdd = jest.fn();
+      const { getByTestId } = render(<AddItemBar onAdd={onAdd} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'milk');
+      fireEvent.press(getByTestId('add-item-submit'));
+      expect(onAdd).toHaveBeenCalledWith('milk', '', null, 'Other');
+    });
+
+    it('submits exact-matched suggestion data when input matches a suggestion', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([milkSuggestion]);
+      const onAdd = jest.fn();
+      const { getByTestId } = render(<AddItemBar onAdd={onAdd} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'milk');
+      fireEvent.press(getByTestId('add-item-submit'));
+      expect(onAdd).toHaveBeenCalledWith('milk', '', 'milk', 'Dairy');
+    });
+
+    it('keyboard submit also uses exact-matched suggestion data', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([milkSuggestion]);
+      const onAdd = jest.fn();
+      const { getByTestId } = render(<AddItemBar onAdd={onAdd} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'milk');
+      fireEvent(getByTestId('add-item-input'), 'submitEditing');
+      expect(onAdd).toHaveBeenCalledWith('milk', '', 'milk', 'Dairy');
+    });
+
+    it('keyboard submit uses raw value when no exact match', () => {
+      (useItemSuggestions as jest.Mock).mockReturnValue([]);
+      const onAdd = jest.fn();
+      const { getByTestId } = render(<AddItemBar onAdd={onAdd} />);
+      fireEvent.changeText(getByTestId('add-item-input'), 'oat milk');
+      fireEvent(getByTestId('add-item-input'), 'submitEditing');
+      expect(onAdd).toHaveBeenCalledWith('oat milk', '', null, 'Other');
+    });
+  });
+});

--- a/src/components/AddItemBar.tsx
+++ b/src/components/AddItemBar.tsx
@@ -9,7 +9,6 @@ import {
 import KitchenOwlIcon from '@/components/KitchenOwlIcon';
 import CameraIcon from '@/components/icons/CameraIcon';
 import { useItemSuggestions } from '@/hooks/useItemSuggestions';
-import { suggestIcons } from '@/data/foodMatcher';
 import { useHouseholdStore } from '@/store/householdStore';
 import { useAuthStore } from '@/store/authStore';
 import { Colors, Spacing, Radii, FontSize } from '@/theme';
@@ -35,12 +34,11 @@ export default function AddItemBar({ onAdd }: AddItemBarProps) {
   );
 
   const suggestions = useItemSuggestions(value, 5, searchFn);
-  const showSuggestions = value.trim().length >= 2 && suggestions.length > 0;
-
-  // Best icon match for whatever the user has typed, used for the "add as typed" row.
-  const typedIconKey = value.trim().length >= 2
-    ? (suggestIcons(value.trim(), 1)[0]?.iconKey ?? null)
+  const trimmedValue = value.trim();
+  const exactMatch = trimmedValue.length >= 2
+    ? (suggestions.find((s) => s.displayName.toLowerCase() === trimmedValue.toLowerCase()) ?? null)
     : null;
+  const showSuggestions = trimmedValue.length >= 2 && suggestions.length > 0;
 
   function commit(name: string, iconKey: string | null, category: string) {
     const trimmed = name.trim();
@@ -51,7 +49,11 @@ export default function AddItemBar({ onAdd }: AddItemBarProps) {
   }
 
   function handleAdd() {
-    commit(value, typedIconKey, 'Other');
+    if (exactMatch) {
+      commit(exactMatch.displayName, exactMatch.iconKey, exactMatch.category);
+    } else {
+      commit(value, null, 'Other');
+    }
   }
 
   function handleSuggestion(s: ItemSuggestion) {
@@ -86,22 +88,20 @@ export default function AddItemBar({ onAdd }: AddItemBarProps) {
       {/* Suggestions */}
       {showSuggestions && (
         <View style={styles.suggestions}>
-          {/* Add-as-typed row — always first, icon matched via Fuse.js */}
-          <TouchableOpacity
-            style={styles.suggestTyped}
-            onPress={handleAdd}
-            activeOpacity={0.8}
-          >
-            <View style={styles.suggestTypedIcon}>
-              {typedIconKey ? (
-                <KitchenOwlIcon iconKey={typedIconKey} size={18} style={{ color: Colors.white }} />
-              ) : (
+          {/* Add-as-typed row — hidden when the typed value exactly matches a suggestion */}
+          {!exactMatch && (
+            <TouchableOpacity
+              style={styles.suggestTyped}
+              onPress={handleAdd}
+              activeOpacity={0.8}
+            >
+              <View style={styles.suggestTypedIcon}>
                 <Text style={styles.suggestTypedPlus}>+</Text>
-              )}
-            </View>
-            <Text style={styles.suggestName} numberOfLines={1}>{value.trim()}</Text>
-            <Text style={styles.suggestArrow}>→</Text>
-          </TouchableOpacity>
+              </View>
+              <Text style={styles.suggestName} numberOfLines={1}>{trimmedValue}</Text>
+              <Text style={styles.suggestArrow}>→</Text>
+            </TouchableOpacity>
+          )}
 
           {suggestions.map((s, i) => (
             <TouchableOpacity


### PR DESCRIPTION
When the user's input exactly matches a suggestion's displayName (case-insensitive), the + typed row is hidden and both the submit button and keyboard return use the matched suggestion's iconKey and category rather than falling back to null/'Other'.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh