### PR TITLE
Refactor: extract item operations service layer

### DIFF
--- a/src/__tests__/items/itemOperations.test.ts
+++ b/src/__tests__/items/itemOperations.test.ts
@@ -14,7 +14,6 @@ jest.mock('@/db/items', () => ({
   updateItemDescription: jest.fn(),
   updateItemNameAndIcon: jest.fn(),
   updateItemCategory: jest.fn(),
-  getItem: jest.fn(),
 }));
 
 jest.mock('@/sync/syncManager', () => ({
@@ -46,7 +45,6 @@ import {
   updateItemDescription,
   updateItemNameAndIcon,
   updateItemCategory,
-  getItem,
 } from '@/db/items';
 import { enqueue, removePendingCheckItem } from '@/sync/syncManager';
 import { matchItem } from '@/data/foodMatcher';
@@ -92,7 +90,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   (enqueue as jest.Mock).mockResolvedValue(undefined);
   (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
-  (getItem as jest.Mock).mockResolvedValue(makeItem());
   (addItemLocally as jest.Mock).mockResolvedValue(makeItem({ localId: 'new-item', name: 'Bread' }));
   (softDeleteItem as jest.Mock).mockResolvedValue(undefined);
   (hardDeleteItem as jest.Mock).mockResolvedValue(undefined);
@@ -234,21 +231,13 @@ describe('addItem', () => {
 
 describe('checkItem', () => {
   it('calls DB checkItem with a timestamp', async () => {
-    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await checkItem({ listContext: LIST_CTX, item: makeItem() });
 
     expect(checkItemDb).toHaveBeenCalledWith('item-1', expect.any(Number));
   });
 
-  it('reads fresh item from DB after the write', async () => {
-    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
-
-    expect(getItem).toHaveBeenCalledWith('item-1');
-  });
-
-  it('enqueues CHECK_ITEM when fresh item has a serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
-
-    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('enqueues CHECK_ITEM when item has a serverId', async () => {
+    await checkItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100 }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'CHECK_ITEM', listServerId: 5, itemServerId: 100 }),
@@ -256,23 +245,23 @@ describe('checkItem', () => {
     );
   });
 
-  it('skips enqueue when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('skips enqueue when item has no serverId', async () => {
+    await checkItem({ listContext: LIST_CTX, item: makeItem({ serverId: null }) });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('skips enqueue when activeServerId is null', async () => {
-    await checkItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+    await checkItem({ listContext: NO_SERVER_CTX, item: makeItem() });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it('returns { checkedAt } matching the timestamp written to DB', async () => {
-    const result = await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('returns updated item with isChecked=true and matching checkedAt', async () => {
+    const result = await checkItem({ listContext: LIST_CTX, item: makeItem() });
 
+    expect(result.isChecked).toBe(true);
+    expect(result.isDirty).toBe(true);
     expect(result.checkedAt).toBeGreaterThan(0);
     const dbCall = (checkItemDb as jest.Mock).mock.calls[0];
     expect(result.checkedAt).toBe(dbCall[1]);
@@ -283,7 +272,7 @@ describe('checkItem', () => {
 
 describe('uncheckItem', () => {
   it('calls removePendingCheckItem first', async () => {
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem() });
 
     expect(removePendingCheckItem).toHaveBeenCalledWith('item-1');
   });
@@ -291,7 +280,7 @@ describe('uncheckItem', () => {
   it('calls DB uncheckItem with isDirty=false when pending op was found', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
 
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem() });
 
     expect(uncheckItemDb).toHaveBeenCalledWith('item-1', false);
     expect(enqueue).not.toHaveBeenCalled();
@@ -299,18 +288,16 @@ describe('uncheckItem', () => {
 
   it('calls DB uncheckItem with isDirty=true when no pending op and item has serverId', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
 
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100 }) });
 
     expect(uncheckItemDb).toHaveBeenCalledWith('item-1', true);
   });
 
   it('enqueues ADD_ITEM when no pending op and item has serverId', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, name: 'Milk', description: '1L' }));
 
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100, name: 'Milk', description: '1L' }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'ADD_ITEM', listServerId: 5, name: 'Milk' }),
@@ -321,42 +308,40 @@ describe('uncheckItem', () => {
   it('skips enqueue when hadPendingOp is true', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
 
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem() });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it('skips enqueue when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('skips enqueue when item has no serverId', async () => {
+    await uncheckItem({ listContext: LIST_CTX, item: makeItem({ serverId: null }) });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('skips enqueue when activeServerId is null', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
-
-    await uncheckItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+    await uncheckItem({ listContext: NO_SERVER_CTX, item: makeItem({ serverId: 100 }) });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it('returns { needsReAdd: true } when ADD_ITEM was enqueued', async () => {
+  it('returns updated item with isChecked=false and isDirty=true when ADD_ITEM was enqueued', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
 
-    const result = await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    const result = await uncheckItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100 }) });
 
-    expect(result.needsReAdd).toBe(true);
+    expect(result.isChecked).toBe(false);
+    expect(result.isDirty).toBe(true);
+    expect(result.checkedAt).toBeNull();
   });
 
-  it('returns { needsReAdd: false } when pending op was cancelled', async () => {
+  it('returns updated item with isDirty=false when pending op was cancelled', async () => {
     (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
 
-    const result = await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    const result = await uncheckItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100 }) });
 
-    expect(result.needsReAdd).toBe(false);
+    expect(result.isChecked).toBe(false);
+    expect(result.isDirty).toBe(false);
   });
 });
 
@@ -364,21 +349,13 @@ describe('uncheckItem', () => {
 
 describe('toggleImportant', () => {
   it('calls toggleItemImportant with the negated value', async () => {
-    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+    await toggleImportant({ listContext: LIST_CTX, item: makeItem({ isImportant: false }) });
 
     expect(toggleItemImportant).toHaveBeenCalledWith('item-1', true);
   });
 
-  it('reads fresh item from DB after the toggle', async () => {
-    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
-
-    expect(getItem).toHaveBeenCalledWith('item-1');
-  });
-
   it('enqueues UPDATE_ITEM_DESC with ! prefix when toggling to important', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true, description: 'cold pressed' }));
-
-    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+    await toggleImportant({ listContext: LIST_CTX, item: makeItem({ serverId: 100, isImportant: false, description: 'cold pressed' }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!cold pressed' }),
@@ -387,9 +364,7 @@ describe('toggleImportant', () => {
   });
 
   it('enqueues UPDATE_ITEM_DESC without ! prefix when toggling to not important', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: false, description: 'cold pressed' }));
-
-    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: true });
+    await toggleImportant({ listContext: LIST_CTX, item: makeItem({ serverId: 100, isImportant: true, description: 'cold pressed' }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: 'cold pressed' }),
@@ -397,18 +372,22 @@ describe('toggleImportant', () => {
     );
   });
 
-  it('skips enqueue when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+  it('skips enqueue when item has no serverId', async () => {
+    await toggleImportant({ listContext: LIST_CTX, item: makeItem({ serverId: null }) });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('skips enqueue when activeServerId is null', async () => {
-    await toggleImportant({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+    await toggleImportant({ listContext: NO_SERVER_CTX, item: makeItem() });
 
     expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('returns updated item with flipped isImportant', async () => {
+    const result = await toggleImportant({ listContext: LIST_CTX, item: makeItem({ isImportant: false }) });
+
+    expect(result.isImportant).toBe(true);
   });
 });
 
@@ -416,21 +395,13 @@ describe('toggleImportant', () => {
 
 describe('deleteItem', () => {
   it('calls softDeleteItem first', async () => {
-    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+    await deleteItem({ listContext: LIST_CTX, item: makeItem() });
 
     expect(softDeleteItem).toHaveBeenCalledWith('item-1');
   });
 
-  it('reads fresh item from DB to guard against stale state', async () => {
-    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
-
-    expect(getItem).toHaveBeenCalledWith('item-1');
-  });
-
-  it('enqueues REMOVE_ITEM when fresh item has a serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
-
-    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('enqueues REMOVE_ITEM when item has a serverId', async () => {
+    await deleteItem({ listContext: LIST_CTX, item: makeItem({ serverId: 100 }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'REMOVE_ITEM', listServerId: 5, itemServerId: 100 }),
@@ -439,17 +410,15 @@ describe('deleteItem', () => {
     expect(hardDeleteItem).not.toHaveBeenCalled();
   });
 
-  it('hard-deletes immediately when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+  it('hard-deletes immediately when item has no serverId', async () => {
+    await deleteItem({ listContext: LIST_CTX, item: makeItem({ serverId: null }) });
 
     expect(hardDeleteItem).toHaveBeenCalledWith('item-1');
     expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('hard-deletes when activeServerId is null', async () => {
-    await deleteItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+    await deleteItem({ listContext: NO_SERVER_CTX, item: makeItem() });
 
     expect(hardDeleteItem).toHaveBeenCalledWith('item-1');
     expect(enqueue).not.toHaveBeenCalled();
@@ -459,7 +428,8 @@ describe('deleteItem', () => {
 // ─── saveItem ────────────────────────────────────────────────────────────────
 
 describe('saveItem', () => {
-  const PARAMS = { listContext: LIST_CTX, itemLocalId: 'item-1', name: 'Almond Milk', description: '500g', iconKey: 'milk' };
+  const BASE_ITEM = makeItem({ serverId: 100 });
+  const PARAMS = { listContext: LIST_CTX, item: BASE_ITEM, name: 'Almond Milk', description: '500g', iconKey: 'milk' };
 
   it('calls updateItemNameAndIcon with the new values', async () => {
     await saveItem(PARAMS);
@@ -467,15 +437,7 @@ describe('saveItem', () => {
     expect(updateItemNameAndIcon).toHaveBeenCalledWith('item-1', 'Almond Milk', '500g', 'milk');
   });
 
-  it('reads fresh item from DB after the write', async () => {
-    await saveItem(PARAMS);
-
-    expect(getItem).toHaveBeenCalledWith('item-1');
-  });
-
   it('enqueues UPDATE_ITEM with catalog fields', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, serverCategoryId: null }));
-
     await saveItem(PARAMS);
 
     expect(enqueue).toHaveBeenCalledWith(
@@ -485,8 +447,6 @@ describe('saveItem', () => {
   });
 
   it('enqueues UPDATE_ITEM_DESC as a second op for the per-list description', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: false }));
-
     await saveItem(PARAMS);
 
     expect(enqueue).toHaveBeenCalledWith(
@@ -495,10 +455,8 @@ describe('saveItem', () => {
     );
   });
 
-  it('prepends ! in UPDATE_ITEM_DESC when fresh item isImportant', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true }));
-
-    await saveItem(PARAMS);
+  it('prepends ! in UPDATE_ITEM_DESC when item isImportant', async () => {
+    await saveItem({ ...PARAMS, item: makeItem({ serverId: 100, isImportant: true }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!500g' }),
@@ -507,9 +465,7 @@ describe('saveItem', () => {
   });
 
   it('does not prepend ! in UPDATE_ITEM regardless of importance', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true }));
-
-    await saveItem(PARAMS);
+    await saveItem({ ...PARAMS, item: makeItem({ serverId: 100, isImportant: true }) });
 
     const updateItemCall = (enqueue as jest.Mock).mock.calls.find(
       ([p]) => p.opType === 'UPDATE_ITEM'
@@ -518,11 +474,7 @@ describe('saveItem', () => {
   });
 
   it('includes serverCategory in UPDATE_ITEM when serverCategoryId is set', async () => {
-    (getItem as jest.Mock).mockResolvedValue(
-      makeItem({ serverId: 100, serverCategoryId: 9, serverCategoryName: 'Dairy', serverCategoryOrdering: 1 })
-    );
-
-    await saveItem(PARAMS);
+    await saveItem({ ...PARAMS, item: makeItem({ serverId: 100, serverCategoryId: 9, serverCategoryName: 'Dairy', serverCategoryOrdering: 1 }) });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -534,8 +486,6 @@ describe('saveItem', () => {
   });
 
   it('passes null category in UPDATE_ITEM when serverCategoryId is null', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, serverCategoryId: null }));
-
     await saveItem(PARAMS);
 
     expect(enqueue).toHaveBeenCalledWith(
@@ -544,10 +494,8 @@ describe('saveItem', () => {
     );
   });
 
-  it('skips both enqueue calls when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await saveItem(PARAMS);
+  it('skips both enqueue calls when item has no serverId', async () => {
+    await saveItem({ ...PARAMS, item: makeItem({ serverId: null }) });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
@@ -557,6 +505,14 @@ describe('saveItem', () => {
 
     expect(enqueue).not.toHaveBeenCalled();
   });
+
+  it('returns updated item with new name, description, iconKey', async () => {
+    const result = await saveItem(PARAMS);
+
+    expect(result.name).toBe('Almond Milk');
+    expect(result.description).toBe('500g');
+    expect(result.iconKey).toBe('milk');
+  });
 });
 
 // ─── moveItemToCategory ───────────────────────────────────────────────────────
@@ -565,21 +521,19 @@ describe('moveItemToCategory', () => {
   const dairyCategory = { id: 9, name: 'Dairy', ordering: 1 };
 
   it('calls updateItemCategory with resolved fields', async () => {
-    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+    await moveItemToCategory({ listContext: LIST_CTX, item: makeItem(), category: dairyCategory });
 
     expect(updateItemCategory).toHaveBeenCalledWith('item-1', 'Dairy', 9, 'Dairy', 1);
   });
 
   it('passes "Uncategorized" and null server fields when category is null', async () => {
-    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: null });
+    await moveItemToCategory({ listContext: LIST_CTX, item: makeItem(), category: null });
 
     expect(updateItemCategory).toHaveBeenCalledWith('item-1', 'Uncategorized', null, null, null);
   });
 
   it('enqueues UPDATE_ITEM with the full item and server category', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, name: 'Milk', description: '1L', iconKey: 'milk_carton' }));
-
-    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+    await moveItemToCategory({ listContext: LIST_CTX, item: makeItem({ serverId: 100, name: 'Milk', description: '1L', iconKey: 'milk_carton' }), category: dairyCategory });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -593,7 +547,7 @@ describe('moveItemToCategory', () => {
   });
 
   it('passes null category in UPDATE_ITEM when no category given', async () => {
-    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: null });
+    await moveItemToCategory({ listContext: LIST_CTX, item: makeItem(), category: null });
 
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ opType: 'UPDATE_ITEM', category: null }),
@@ -601,17 +555,33 @@ describe('moveItemToCategory', () => {
     );
   });
 
-  it('skips enqueue when fresh item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+  it('skips enqueue when item has no serverId', async () => {
+    await moveItemToCategory({ listContext: LIST_CTX, item: makeItem({ serverId: null }), category: dairyCategory });
 
     expect(enqueue).not.toHaveBeenCalled();
   });
 
   it('skips enqueue when activeServerId is null', async () => {
-    await moveItemToCategory({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1', category: dairyCategory });
+    await moveItemToCategory({ listContext: NO_SERVER_CTX, item: makeItem(), category: dairyCategory });
 
     expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('returns updated item with new category fields and isDirty=true', async () => {
+    const result = await moveItemToCategory({ listContext: LIST_CTX, item: makeItem(), category: dairyCategory });
+
+    expect(result.category).toBe('Dairy');
+    expect(result.serverCategoryId).toBe(9);
+    expect(result.serverCategoryName).toBe('Dairy');
+    expect(result.serverCategoryOrdering).toBe(1);
+    expect(result.isDirty).toBe(true);
+  });
+
+  it('returns updated item with Uncategorized and null fields when no category', async () => {
+    const result = await moveItemToCategory({ listContext: LIST_CTX, item: makeItem(), category: null });
+
+    expect(result.category).toBe('Uncategorized');
+    expect(result.serverCategoryId).toBeNull();
+    expect(result.serverCategoryName).toBeNull();
   });
 });

--- a/src/__tests__/items/itemOperations.test.ts
+++ b/src/__tests__/items/itemOperations.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Tests for itemOperations — verifies that every operation correctly pairs
+ * its SQLite write with the right sync enqueue (and skips the enqueue when
+ * the item or list has no serverId).
+ */
+
+jest.mock('@/db/items', () => ({
+  addItemLocally: jest.fn(),
+  softDeleteItem: jest.fn(),
+  hardDeleteItem: jest.fn(),
+  checkItem: jest.fn(),
+  uncheckItem: jest.fn(),
+  toggleItemImportant: jest.fn(),
+  updateItemDescription: jest.fn(),
+  updateItemNameAndIcon: jest.fn(),
+  updateItemCategory: jest.fn(),
+  getItem: jest.fn(),
+}));
+
+jest.mock('@/sync/syncManager', () => ({
+  enqueue: jest.fn().mockResolvedValue(undefined),
+  removePendingCheckItem: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('@/data/foodMatcher', () => ({
+  matchItem: jest.fn(() => ({ iconKey: 'apple', category: 'Produce' })),
+}));
+
+jest.mock('@/utils/mergeQuantities', () => ({
+  mergeQuantities: jest.fn((a: string, b: string) =>
+    a && b ? `${a} + ${b}` : a || b
+  ),
+}));
+
+jest.mock('@/db/history', () => ({
+  recordItemUsed: jest.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  addItemLocally,
+  softDeleteItem,
+  hardDeleteItem,
+  checkItem as checkItemDb,
+  uncheckItem as uncheckItemDb,
+  toggleItemImportant,
+  updateItemDescription,
+  updateItemNameAndIcon,
+  updateItemCategory,
+  getItem,
+} from '@/db/items';
+import { enqueue, removePendingCheckItem } from '@/sync/syncManager';
+import { matchItem } from '@/data/foodMatcher';
+import { mergeQuantities } from '@/utils/mergeQuantities';
+import { recordItemUsed } from '@/db/history';
+import type { LocalItem } from '@/db/items';
+import {
+  addItem,
+  checkItem,
+  uncheckItem,
+  toggleImportant,
+  deleteItem,
+  saveItem,
+  moveItemToCategory,
+} from '@/items/itemOperations';
+
+function makeItem(overrides: Partial<LocalItem> = {}): LocalItem {
+  return {
+    localId: 'item-1',
+    serverId: 100,
+    listLocalId: 'list-local-1',
+    name: 'Milk',
+    description: '',
+    iconKey: 'milk_carton',
+    category: 'Dairy & Eggs',
+    serverCategoryId: null,
+    serverCategoryName: null,
+    serverCategoryOrdering: null,
+    isChecked: false,
+    isImportant: false,
+    isDirty: false,
+    isDeleted: false,
+    createdAt: 1000,
+    checkedAt: null,
+    ...overrides,
+  };
+}
+
+const LIST_CTX = { activeLocalId: 'list-local-1', activeServerId: 5 };
+const NO_SERVER_CTX = { activeLocalId: 'list-local-1', activeServerId: null };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (enqueue as jest.Mock).mockResolvedValue(undefined);
+  (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
+  (getItem as jest.Mock).mockResolvedValue(makeItem());
+  (addItemLocally as jest.Mock).mockResolvedValue(makeItem({ localId: 'new-item', name: 'Bread' }));
+  (softDeleteItem as jest.Mock).mockResolvedValue(undefined);
+  (hardDeleteItem as jest.Mock).mockResolvedValue(undefined);
+  (checkItemDb as jest.Mock).mockResolvedValue(undefined);
+  (uncheckItemDb as jest.Mock).mockResolvedValue(undefined);
+  (toggleItemImportant as jest.Mock).mockResolvedValue(undefined);
+  (updateItemDescription as jest.Mock).mockResolvedValue(undefined);
+  (updateItemNameAndIcon as jest.Mock).mockResolvedValue(undefined);
+  (updateItemCategory as jest.Mock).mockResolvedValue(undefined);
+  (recordItemUsed as jest.Mock).mockResolvedValue(undefined);
+});
+
+// ─── addItem ─────────────────────────────────────────────────────────────────
+
+describe('addItem', () => {
+  describe('new item path', () => {
+    it('calls matchItem and addItemLocally when no iconKey provided', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [], name: 'Bread', description: '', iconKey: null, category: 'Other' });
+
+      expect(matchItem).toHaveBeenCalledWith('Bread');
+      expect(addItemLocally).toHaveBeenCalledWith('list-local-1', 'Bread', '', 'apple', 'Produce');
+    });
+
+    it('uses provided iconKey and category, skips matchItem', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [], name: 'Banana', description: '', iconKey: 'banana', category: 'Produce' });
+
+      expect(matchItem).not.toHaveBeenCalled();
+      expect(addItemLocally).toHaveBeenCalledWith('list-local-1', 'Banana', '', 'banana', 'Produce');
+    });
+
+    it('calls recordItemUsed after adding', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [], name: 'Bread', description: '', iconKey: null, category: 'Other' });
+
+      expect(recordItemUsed).toHaveBeenCalled();
+    });
+
+    it('enqueues ADD_ITEM when list has a serverId', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [], name: 'Bread', description: '', iconKey: null, category: 'Other' });
+
+      expect(enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ opType: 'ADD_ITEM', listServerId: 5 }),
+        'list-local-1'
+      );
+    });
+
+    it('skips ADD_ITEM enqueue when activeServerId is null', async () => {
+      await addItem({ listContext: NO_SERVER_CTX, currentItems: [], name: 'Bread', description: '', iconKey: null, category: 'Other' });
+
+      expect(enqueue).not.toHaveBeenCalled();
+    });
+
+    it('returns { action: "added", item }', async () => {
+      const result = await addItem({ listContext: LIST_CTX, currentItems: [], name: 'Bread', description: '', iconKey: null, category: 'Other' });
+
+      expect(result.action).toBe('added');
+      expect(result.item.localId).toBe('new-item');
+    });
+  });
+
+  describe('duplicate merge path', () => {
+    const existingItem = makeItem({ localId: 'item-milk', serverId: 100, name: 'Milk', description: '3L' });
+
+    it('calls mergeQuantities and updateItemDescription when name matches', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [existingItem], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(mergeQuantities).toHaveBeenCalledWith('3L', '2L');
+      expect(updateItemDescription).toHaveBeenCalledWith('item-milk', '3L + 2L');
+      expect(addItemLocally).not.toHaveBeenCalled();
+    });
+
+    it('enqueues UPDATE_ITEM_DESC with merged description', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [existingItem], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', listServerId: 5, itemServerId: 100, description: '3L + 2L' }),
+        'list-local-1'
+      );
+    });
+
+    it('prefixes ! in server description when existing item isImportant', async () => {
+      const important = { ...existingItem, isImportant: true };
+      await addItem({ listContext: LIST_CTX, currentItems: [important], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!3L + 2L' }),
+        'list-local-1'
+      );
+    });
+
+    it('skips enqueue when existing item has no serverId', async () => {
+      const noServer = { ...existingItem, serverId: null };
+      await addItem({ listContext: LIST_CTX, currentItems: [noServer], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(enqueue).not.toHaveBeenCalled();
+      expect(updateItemDescription).toHaveBeenCalled();
+    });
+
+    it('skips enqueue when list has no serverId', async () => {
+      await addItem({ listContext: NO_SERVER_CTX, currentItems: [existingItem], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(enqueue).not.toHaveBeenCalled();
+      expect(updateItemDescription).toHaveBeenCalled();
+    });
+
+    it('matches name case-insensitively', async () => {
+      await addItem({ listContext: LIST_CTX, currentItems: [existingItem], name: 'MILK', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(mergeQuantities).toHaveBeenCalledWith('3L', '2L');
+      expect(addItemLocally).not.toHaveBeenCalled();
+    });
+
+    it('does not merge with checked items — falls through to new item path', async () => {
+      const checked = { ...existingItem, isChecked: true };
+      await addItem({ listContext: LIST_CTX, currentItems: [checked], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(addItemLocally).toHaveBeenCalled();
+      expect(updateItemDescription).not.toHaveBeenCalled();
+    });
+
+    it('does not merge with soft-deleted items — falls through to new item path', async () => {
+      const deleted = { ...existingItem, isDeleted: true };
+      await addItem({ listContext: LIST_CTX, currentItems: [deleted], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(addItemLocally).toHaveBeenCalled();
+      expect(updateItemDescription).not.toHaveBeenCalled();
+    });
+
+    it('returns { action: "merged", item } with updated description', async () => {
+      const result = await addItem({ listContext: LIST_CTX, currentItems: [existingItem], name: 'Milk', description: '2L', iconKey: null, category: 'Dairy' });
+
+      expect(result.action).toBe('merged');
+      expect(result.item.localId).toBe('item-milk');
+      expect(result.item.description).toBe('3L + 2L');
+    });
+  });
+});
+
+// ─── checkItem ───────────────────────────────────────────────────────────────
+
+describe('checkItem', () => {
+  it('calls DB checkItem with a timestamp', async () => {
+    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(checkItemDb).toHaveBeenCalledWith('item-1', expect.any(Number));
+  });
+
+  it('reads fresh item from DB after the write', async () => {
+    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(getItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('enqueues CHECK_ITEM when fresh item has a serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
+
+    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'CHECK_ITEM', listServerId: 5, itemServerId: 100 }),
+      'list-local-1'
+    );
+  });
+
+  it('skips enqueue when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when activeServerId is null', async () => {
+    await checkItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('returns { checkedAt } matching the timestamp written to DB', async () => {
+    const result = await checkItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(result.checkedAt).toBeGreaterThan(0);
+    const dbCall = (checkItemDb as jest.Mock).mock.calls[0];
+    expect(result.checkedAt).toBe(dbCall[1]);
+  });
+});
+
+// ─── uncheckItem ─────────────────────────────────────────────────────────────
+
+describe('uncheckItem', () => {
+  it('calls removePendingCheckItem first', async () => {
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(removePendingCheckItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('calls DB uncheckItem with isDirty=false when pending op was found', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
+
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(uncheckItemDb).toHaveBeenCalledWith('item-1', false);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('calls DB uncheckItem with isDirty=true when no pending op and item has serverId', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
+
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(uncheckItemDb).toHaveBeenCalledWith('item-1', true);
+  });
+
+  it('enqueues ADD_ITEM when no pending op and item has serverId', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, name: 'Milk', description: '1L' }));
+
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'ADD_ITEM', listServerId: 5, name: 'Milk' }),
+      'list-local-1'
+    );
+  });
+
+  it('skips enqueue when hadPendingOp is true', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
+
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when activeServerId is null', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
+
+    await uncheckItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('returns { needsReAdd: true } when ADD_ITEM was enqueued', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
+
+    const result = await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(result.needsReAdd).toBe(true);
+  });
+
+  it('returns { needsReAdd: false } when pending op was cancelled', async () => {
+    (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
+
+    const result = await uncheckItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(result.needsReAdd).toBe(false);
+  });
+});
+
+// ─── toggleImportant ─────────────────────────────────────────────────────────
+
+describe('toggleImportant', () => {
+  it('calls toggleItemImportant with the negated value', async () => {
+    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+
+    expect(toggleItemImportant).toHaveBeenCalledWith('item-1', true);
+  });
+
+  it('reads fresh item from DB after the toggle', async () => {
+    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+
+    expect(getItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('enqueues UPDATE_ITEM_DESC with ! prefix when toggling to important', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true, description: 'cold pressed' }));
+
+    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!cold pressed' }),
+      'list-local-1'
+    );
+  });
+
+  it('enqueues UPDATE_ITEM_DESC without ! prefix when toggling to not important', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: false, description: 'cold pressed' }));
+
+    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: true });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: 'cold pressed' }),
+      'list-local-1'
+    );
+  });
+
+  it('skips enqueue when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await toggleImportant({ listContext: LIST_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when activeServerId is null', async () => {
+    await toggleImportant({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1', currentIsImportant: false });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});
+
+// ─── deleteItem ──────────────────────────────────────────────────────────────
+
+describe('deleteItem', () => {
+  it('calls softDeleteItem first', async () => {
+    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(softDeleteItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('reads fresh item from DB to guard against stale state', async () => {
+    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(getItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('enqueues REMOVE_ITEM when fresh item has a serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
+
+    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'REMOVE_ITEM', listServerId: 5, itemServerId: 100 }),
+      'list-local-1'
+    );
+    expect(hardDeleteItem).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes immediately when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await deleteItem({ listContext: LIST_CTX, itemLocalId: 'item-1' });
+
+    expect(hardDeleteItem).toHaveBeenCalledWith('item-1');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes when activeServerId is null', async () => {
+    await deleteItem({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1' });
+
+    expect(hardDeleteItem).toHaveBeenCalledWith('item-1');
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});
+
+// ─── saveItem ────────────────────────────────────────────────────────────────
+
+describe('saveItem', () => {
+  const PARAMS = { listContext: LIST_CTX, itemLocalId: 'item-1', name: 'Almond Milk', description: '500g', iconKey: 'milk' };
+
+  it('calls updateItemNameAndIcon with the new values', async () => {
+    await saveItem(PARAMS);
+
+    expect(updateItemNameAndIcon).toHaveBeenCalledWith('item-1', 'Almond Milk', '500g', 'milk');
+  });
+
+  it('reads fresh item from DB after the write', async () => {
+    await saveItem(PARAMS);
+
+    expect(getItem).toHaveBeenCalledWith('item-1');
+  });
+
+  it('enqueues UPDATE_ITEM with catalog fields', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, serverCategoryId: null }));
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM', listServerId: 5, itemServerId: 100, name: 'Almond Milk' }),
+      'list-local-1'
+    );
+  });
+
+  it('enqueues UPDATE_ITEM_DESC as a second op for the per-list description', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: false }));
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '500g' }),
+      'list-local-1'
+    );
+  });
+
+  it('prepends ! in UPDATE_ITEM_DESC when fresh item isImportant', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true }));
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!500g' }),
+      'list-local-1'
+    );
+  });
+
+  it('does not prepend ! in UPDATE_ITEM regardless of importance', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true }));
+
+    await saveItem(PARAMS);
+
+    const updateItemCall = (enqueue as jest.Mock).mock.calls.find(
+      ([p]) => p.opType === 'UPDATE_ITEM'
+    );
+    expect(updateItemCall[0].description).toBe('500g');
+  });
+
+  it('includes serverCategory in UPDATE_ITEM when serverCategoryId is set', async () => {
+    (getItem as jest.Mock).mockResolvedValue(
+      makeItem({ serverId: 100, serverCategoryId: 9, serverCategoryName: 'Dairy', serverCategoryOrdering: 1 })
+    );
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opType: 'UPDATE_ITEM',
+        category: { id: 9, name: 'Dairy', ordering: 1 },
+      }),
+      'list-local-1'
+    );
+  });
+
+  it('passes null category in UPDATE_ITEM when serverCategoryId is null', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, serverCategoryId: null }));
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM', category: null }),
+      'list-local-1'
+    );
+  });
+
+  it('skips both enqueue calls when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await saveItem(PARAMS);
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips both enqueue calls when activeServerId is null', async () => {
+    await saveItem({ ...PARAMS, listContext: NO_SERVER_CTX });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});
+
+// ─── moveItemToCategory ───────────────────────────────────────────────────────
+
+describe('moveItemToCategory', () => {
+  const dairyCategory = { id: 9, name: 'Dairy', ordering: 1 };
+
+  it('calls updateItemCategory with resolved fields', async () => {
+    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+
+    expect(updateItemCategory).toHaveBeenCalledWith('item-1', 'Dairy', 9, 'Dairy', 1);
+  });
+
+  it('passes "Uncategorized" and null server fields when category is null', async () => {
+    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: null });
+
+    expect(updateItemCategory).toHaveBeenCalledWith('item-1', 'Uncategorized', null, null, null);
+  });
+
+  it('enqueues UPDATE_ITEM with the full item and server category', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, name: 'Milk', description: '1L', iconKey: 'milk_carton' }));
+
+    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opType: 'UPDATE_ITEM',
+        listServerId: 5,
+        itemServerId: 100,
+        category: { id: 9, name: 'Dairy', ordering: 1 },
+      }),
+      'list-local-1'
+    );
+  });
+
+  it('passes null category in UPDATE_ITEM when no category given', async () => {
+    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: null });
+
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'UPDATE_ITEM', category: null }),
+      'list-local-1'
+    );
+  });
+
+  it('skips enqueue when fresh item has no serverId', async () => {
+    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
+
+    await moveItemToCategory({ listContext: LIST_CTX, itemLocalId: 'item-1', category: dairyCategory });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when activeServerId is null', async () => {
+    await moveItemToCategory({ listContext: NO_SERVER_CTX, itemLocalId: 'item-1', category: dairyCategory });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/store/listDetailStore.test.ts
+++ b/src/__tests__/store/listDetailStore.test.ts
@@ -131,12 +131,12 @@ beforeEach(() => {
     default_shopping_list: null,
   });
   // Default op return values
-  (checkItemOp as jest.Mock).mockResolvedValue({ checkedAt: 1000 });
-  (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: false });
-  (toggleImportantOp as jest.Mock).mockResolvedValue(undefined);
+  (checkItemOp as jest.Mock).mockResolvedValue(makeItem({ isChecked: true, isDirty: true, checkedAt: 1000 }));
+  (uncheckItemOp as jest.Mock).mockResolvedValue(makeItem({ isChecked: false, isDirty: false, checkedAt: null }));
+  (toggleImportantOp as jest.Mock).mockResolvedValue(makeItem({ isImportant: true }));
   (deleteItemOp as jest.Mock).mockResolvedValue(undefined);
-  (saveItemOp as jest.Mock).mockResolvedValue(undefined);
-  (moveItemToCategoryOp as jest.Mock).mockResolvedValue(undefined);
+  (saveItemOp as jest.Mock).mockResolvedValue(makeItem());
+  (moveItemToCategoryOp as jest.Mock).mockResolvedValue(makeItem());
   (addItemOp as jest.Mock).mockResolvedValue({ action: 'added', item: makeItem({ localId: 'new-item', name: 'Bread' }) });
 });
 
@@ -311,12 +311,12 @@ describe('toggleDone', () => {
 
     expect(checkItemOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
+      item: expect.objectContaining({ localId: 'item-1' }),
     });
   });
 
   it('updates item to isChecked=true in state after checking', async () => {
-    (checkItemOp as jest.Mock).mockResolvedValue({ checkedAt: 9999 });
+    (checkItemOp as jest.Mock).mockResolvedValue(makeItem({ isChecked: true, isDirty: true, checkedAt: 9999 }));
 
     await useListDetailStore.getState().toggleDone('item-1');
 
@@ -333,13 +333,13 @@ describe('toggleDone', () => {
 
     expect(uncheckItemOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
+      item: expect.objectContaining({ localId: 'item-1' }),
     });
   });
 
   it('updates item to isChecked=false in state after unchecking', async () => {
     useListDetailStore.setState({ items: [makeItem({ isChecked: true })] });
-    (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: true });
+    (uncheckItemOp as jest.Mock).mockResolvedValue(makeItem({ isChecked: false, isDirty: true, checkedAt: null }));
 
     await useListDetailStore.getState().toggleDone('item-1');
 
@@ -351,7 +351,7 @@ describe('toggleDone', () => {
 
   it('sets isDirty=false when needsReAdd is false', async () => {
     useListDetailStore.setState({ items: [makeItem({ isChecked: true })] });
-    (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: false });
+    (uncheckItemOp as jest.Mock).mockResolvedValue(makeItem({ isChecked: false, isDirty: false, checkedAt: null }));
 
     await useListDetailStore.getState().toggleDone('item-1');
 
@@ -382,8 +382,7 @@ describe('toggleImportant', () => {
 
     expect(toggleImportantOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
-      currentIsImportant: false,
+      item: expect.objectContaining({ localId: 'item-1', isImportant: false }),
     });
   });
 
@@ -416,7 +415,7 @@ describe('deleteItem', () => {
 
     expect(deleteItemOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
+      item: expect.objectContaining({ localId: 'item-1' }),
     });
   });
 
@@ -449,7 +448,7 @@ describe('saveItem', () => {
 
     expect(saveItemOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
+      item: expect.objectContaining({ localId: 'item-1' }),
       name: 'Almond Milk',
       description: '500g',
       iconKey: 'milk',
@@ -457,6 +456,8 @@ describe('saveItem', () => {
   });
 
   it('updates name, description, iconKey in Zustand state', async () => {
+    (saveItemOp as jest.Mock).mockResolvedValue(makeItem({ name: 'Almond Milk', description: '500g', iconKey: 'milk' }));
+
     await useListDetailStore.getState().saveItem('item-1', 'Almond Milk', '500g', 'milk');
 
     const item = useListDetailStore.getState().items[0];
@@ -562,7 +563,7 @@ describe('moveItemToCategory', () => {
 
     expect(moveItemToCategoryOp).toHaveBeenCalledWith({
       listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
-      itemLocalId: 'item-1',
+      item: expect.objectContaining({ localId: 'item-1' }),
       category: dairyCategory,
     });
   });
@@ -576,6 +577,10 @@ describe('moveItemToCategory', () => {
   });
 
   it('updates category fields in Zustand state', async () => {
+    (moveItemToCategoryOp as jest.Mock).mockResolvedValue(
+      makeItem({ category: 'Dairy', serverCategoryId: 9, serverCategoryName: 'Dairy', isDirty: true })
+    );
+
     await useListDetailStore.getState().moveItemToCategory('item-1', 9);
 
     const item = useListDetailStore.getState().items[0];
@@ -585,6 +590,10 @@ describe('moveItemToCategory', () => {
   });
 
   it('sets Uncategorized when categoryId is null', async () => {
+    (moveItemToCategoryOp as jest.Mock).mockResolvedValue(
+      makeItem({ category: 'Uncategorized', serverCategoryId: null })
+    );
+
     await useListDetailStore.getState().moveItemToCategory('item-1', null);
 
     const item = useListDetailStore.getState().items[0];

--- a/src/__tests__/store/listDetailStore.test.ts
+++ b/src/__tests__/store/listDetailStore.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for listDetailStore actions.
- * All DB/sync dependencies are mocked; actions are called directly via getState().
+ * Item DB/sync logic now lives in @/items/itemOperations — that module is mocked
+ * here so each action test focuses purely on: correct op called + Zustand state.
  */
 
 jest.mock('expo-secure-store', () => ({
@@ -10,75 +11,56 @@ jest.mock('expo-secure-store', () => ({
 
 jest.mock('@/db/items', () => ({
   getItemsForList: jest.fn(),
-  getItem: jest.fn(),
-  addItemLocally: jest.fn(),
-  softDeleteItem: jest.fn(),
-  hardDeleteItem: jest.fn(),
   upsertItemFromServer: jest.fn(),
   removeItemsDeletedOnServer: jest.fn(),
-  checkItem: jest.fn(),
-  uncheckItem: jest.fn(),
-  markItemCheckSynced: jest.fn(),
   clearCheckedItems: jest.fn(),
   clearExpiredCheckedItems: jest.fn(),
-  toggleItemImportant: jest.fn(),
-  updateItemNameAndIcon: jest.fn(),
-  updateItemDescription: jest.fn(),
-}));
-
-jest.mock('@/utils/mergeQuantities', () => ({
-  mergeQuantities: jest.fn((existing: string, incoming: string) =>
-    existing && incoming ? `${existing} + ${incoming}` : existing || incoming
-  ),
+  getItem: jest.fn(),
 }));
 
 jest.mock('@/db/lists', () => ({
   getAllLists: jest.fn(),
+  upsertListFromServer: jest.fn(),
 }));
 
-jest.mock('@/sync/syncManager', () => ({
-  enqueue: jest.fn().mockResolvedValue(undefined),
-  removePendingCheckItem: jest.fn().mockResolvedValue(false),
+jest.mock('@/items/itemOperations', () => ({
+  addItem: jest.fn(),
+  checkItem: jest.fn(),
+  uncheckItem: jest.fn(),
+  toggleImportant: jest.fn(),
+  deleteItem: jest.fn(),
+  saveItem: jest.fn(),
+  moveItemToCategory: jest.fn(),
 }));
 
-jest.mock('@/db/history', () => ({
-  recordItemUsed: jest.fn(),
+const mockGetShoppingLists = jest.fn();
+const mockGetHousehold = jest.fn();
+const mockGetCategories = jest.fn();
+jest.mock('@/store/authStore', () => ({
+  useAuthStore: {
+    getState: jest.fn(() => ({
+      shoppingListsApi: { getShoppingLists: mockGetShoppingLists },
+      householdsApi: { getHousehold: mockGetHousehold, getCategories: mockGetCategories },
+    })),
+  },
 }));
 
 jest.mock('@/data/foodMatcher', () => ({
   matchItem: jest.fn(() => ({ iconKey: 'apple', category: 'Produce' })),
 }));
 
-const mockGetShoppingLists = jest.fn();
-const mockGetHousehold = jest.fn();
-jest.mock('@/store/authStore', () => ({
-  useAuthStore: {
-    getState: jest.fn(() => ({
-      shoppingListsApi: { getShoppingLists: mockGetShoppingLists },
-      householdsApi: { getHousehold: mockGetHousehold },
-    })),
-  },
-}));
-
 import { getItemAsync, setItemAsync } from 'expo-secure-store';
-import {
-  getItemsForList,
-  getItem,
-  addItemLocally,
-  softDeleteItem,
-  hardDeleteItem,
-  checkItem,
-  uncheckItem,
-  clearCheckedItems,
-  clearExpiredCheckedItems,
-  toggleItemImportant,
-  updateItemNameAndIcon,
-  updateItemDescription,
-} from '@/db/items';
+import { getItemsForList, clearCheckedItems, clearExpiredCheckedItems } from '@/db/items';
 import { getAllLists } from '@/db/lists';
-import { enqueue, removePendingCheckItem } from '@/sync/syncManager';
-import { recordItemUsed } from '@/db/history';
-import { mergeQuantities } from '@/utils/mergeQuantities';
+import {
+  addItem as addItemOp,
+  checkItem as checkItemOp,
+  uncheckItem as uncheckItemOp,
+  toggleImportant as toggleImportantOp,
+  deleteItem as deleteItemOp,
+  saveItem as saveItemOp,
+  moveItemToCategory as moveItemToCategoryOp,
+} from '@/items/itemOperations';
 import { useListDetailStore } from '@/store/listDetailStore';
 import type { LocalItem } from '@/db/items';
 import type { LocalList } from '@/db/lists';
@@ -124,6 +106,7 @@ const initialState = {
   activeName: '',
   items: [],
   allLists: [],
+  allCategories: [],
   loading: true,
   refreshing: false,
   listPickerVisible: false,
@@ -139,6 +122,7 @@ beforeEach(() => {
   (clearExpiredCheckedItems as jest.Mock).mockResolvedValue(undefined);
   (getAllLists as jest.Mock).mockResolvedValue([]);
   (mockGetShoppingLists as jest.Mock).mockResolvedValue([]);
+  (mockGetCategories as jest.Mock).mockResolvedValue([]);
   (mockGetHousehold as jest.Mock).mockResolvedValue({
     id: 1,
     name: 'Home',
@@ -146,6 +130,14 @@ beforeEach(() => {
     member: [],
     default_shopping_list: null,
   });
+  // Default op return values
+  (checkItemOp as jest.Mock).mockResolvedValue({ checkedAt: 1000 });
+  (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: false });
+  (toggleImportantOp as jest.Mock).mockResolvedValue(undefined);
+  (deleteItemOp as jest.Mock).mockResolvedValue(undefined);
+  (saveItemOp as jest.Mock).mockResolvedValue(undefined);
+  (moveItemToCategoryOp as jest.Mock).mockResolvedValue(undefined);
+  (addItemOp as jest.Mock).mockResolvedValue({ action: 'added', item: makeItem({ localId: 'new-item', name: 'Bread' }) });
 });
 
 // ─── bootstrap ───────────────────────────────────────────────────────────────
@@ -307,71 +299,104 @@ describe('reloadAfterSync', () => {
 
 describe('toggleDone', () => {
   beforeEach(() => {
-    (checkItem as jest.Mock).mockResolvedValue(undefined);
-    (uncheckItem as jest.Mock).mockResolvedValue(undefined);
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
-    useListDetailStore.setState({ activeLocalId: 'list-local-1', activeServerId: 5 });
+    useListDetailStore.setState({
+      items: [makeItem()],
+      activeLocalId: 'list-local-1',
+      activeServerId: 5,
+    });
   });
 
-  it('calls checkItem and enqueues CHECK_ITEM when checking an item', async () => {
-    const item = makeItem({ isChecked: false });
-    useListDetailStore.setState({ items: [item] });
+  it('calls checkItemOp with correct list context when checking', async () => {
+    await useListDetailStore.getState().toggleDone('item-1');
+
+    expect(checkItemOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+    });
+  });
+
+  it('updates item to isChecked=true in state after checking', async () => {
+    (checkItemOp as jest.Mock).mockResolvedValue({ checkedAt: 9999 });
 
     await useListDetailStore.getState().toggleDone('item-1');
 
-    expect(checkItem).toHaveBeenCalledWith('item-1', expect.any(Number));
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'CHECK_ITEM', itemServerId: 100 }),
-      'list-local-1'
-    );
-    expect(useListDetailStore.getState().items[0].isChecked).toBe(true);
+    const item = useListDetailStore.getState().items[0];
+    expect(item.isChecked).toBe(true);
+    expect(item.isDirty).toBe(true);
+    expect(item.checkedAt).toBe(9999);
   });
 
-  it('calls uncheckItem and cancels pending op when unchecking', async () => {
-    const item = makeItem({ isChecked: true });
-    useListDetailStore.setState({ items: [item] });
-    (removePendingCheckItem as jest.Mock).mockResolvedValue(true);
+  it('calls uncheckItemOp with correct list context when unchecking', async () => {
+    useListDetailStore.setState({ items: [makeItem({ isChecked: true })] });
 
     await useListDetailStore.getState().toggleDone('item-1');
 
-    expect(uncheckItem).toHaveBeenCalledWith('item-1', false);
-    expect(enqueue).not.toHaveBeenCalled();
-    expect(useListDetailStore.getState().items[0].isChecked).toBe(false);
+    expect(uncheckItemOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+    });
   });
 
-  it('re-adds to server via ADD_ITEM when uncheck has no pending op', async () => {
-    const item = makeItem({ isChecked: true });
-    useListDetailStore.setState({ items: [item] });
-    (removePendingCheckItem as jest.Mock).mockResolvedValue(false);
+  it('updates item to isChecked=false in state after unchecking', async () => {
+    useListDetailStore.setState({ items: [makeItem({ isChecked: true })] });
+    (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: true });
 
     await useListDetailStore.getState().toggleDone('item-1');
 
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'ADD_ITEM' }),
-      'list-local-1'
-    );
+    const item = useListDetailStore.getState().items[0];
+    expect(item.isChecked).toBe(false);
+    expect(item.isDirty).toBe(true);
+    expect(item.checkedAt).toBeNull();
+  });
+
+  it('sets isDirty=false when needsReAdd is false', async () => {
+    useListDetailStore.setState({ items: [makeItem({ isChecked: true })] });
+    (uncheckItemOp as jest.Mock).mockResolvedValue({ needsReAdd: false });
+
+    await useListDetailStore.getState().toggleDone('item-1');
+
+    expect(useListDetailStore.getState().items[0].isDirty).toBe(false);
   });
 
   it('does nothing for unknown localId', async () => {
     useListDetailStore.setState({ items: [] });
     await useListDetailStore.getState().toggleDone('ghost');
-    expect(checkItem).not.toHaveBeenCalled();
-    expect(uncheckItem).not.toHaveBeenCalled();
+    expect(checkItemOp).not.toHaveBeenCalled();
+    expect(uncheckItemOp).not.toHaveBeenCalled();
   });
 });
 
 // ─── toggleImportant ──────────────────────────────────────────────────────────
 
 describe('toggleImportant', () => {
-  it('toggles isImportant and calls toggleItemImportant', async () => {
-    const item = makeItem({ isImportant: false });
-    useListDetailStore.setState({ items: [item] });
-    (toggleItemImportant as jest.Mock).mockResolvedValue(undefined);
+  beforeEach(() => {
+    useListDetailStore.setState({
+      items: [makeItem({ isImportant: false })],
+      activeLocalId: 'list-local-1',
+      activeServerId: 5,
+    });
+  });
 
+  it('calls toggleImportantOp with correct params', async () => {
     await useListDetailStore.getState().toggleImportant('item-1');
 
-    expect(toggleItemImportant).toHaveBeenCalledWith('item-1', true);
+    expect(toggleImportantOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+      currentIsImportant: false,
+    });
+  });
+
+  it('flips isImportant in Zustand state', async () => {
+    await useListDetailStore.getState().toggleImportant('item-1');
+
     expect(useListDetailStore.getState().items[0].isImportant).toBe(true);
+  });
+
+  it('does nothing for unknown localId', async () => {
+    useListDetailStore.setState({ items: [] });
+    await useListDetailStore.getState().toggleImportant('ghost');
+    expect(toggleImportantOp).not.toHaveBeenCalled();
   });
 });
 
@@ -384,37 +409,27 @@ describe('deleteItem', () => {
       activeLocalId: 'list-local-1',
       activeServerId: 5,
     });
-    (softDeleteItem as jest.Mock).mockResolvedValue(undefined);
-    (hardDeleteItem as jest.Mock).mockResolvedValue(undefined);
   });
 
-  it('enqueues REMOVE_ITEM when item has a serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100 }));
-
+  it('calls deleteItemOp with correct params', async () => {
     await useListDetailStore.getState().deleteItem('item-1');
 
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'REMOVE_ITEM', itemServerId: 100 }),
-      'list-local-1'
-    );
-    expect(hardDeleteItem).not.toHaveBeenCalled();
+    expect(deleteItemOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+    });
   });
 
-  it('hard-deletes immediately when item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await useListDetailStore.getState().deleteItem('item-1');
-
-    expect(hardDeleteItem).toHaveBeenCalledWith('item-1');
-    expect(enqueue).not.toHaveBeenCalled();
-  });
-
-  it('removes item from state', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
+  it('removes item from Zustand state', async () => {
     await useListDetailStore.getState().deleteItem('item-1');
 
     expect(useListDetailStore.getState().items).toEqual([]);
+  });
+
+  it('does nothing when no activeLocalId', async () => {
+    useListDetailStore.setState({ activeLocalId: null });
+    await useListDetailStore.getState().deleteItem('item-1');
+    expect(deleteItemOp).not.toHaveBeenCalled();
   });
 });
 
@@ -427,231 +442,83 @@ describe('saveItem', () => {
       activeLocalId: 'list-local-1',
       activeServerId: 5,
     });
-    (updateItemNameAndIcon as jest.Mock).mockResolvedValue(undefined);
   });
 
-  it('enqueues UPDATE_ITEM when item has a serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, serverCategoryId: null }));
+  it('calls saveItemOp with correct params', async () => {
+    await useListDetailStore.getState().saveItem('item-1', 'Almond Milk', '500g', 'milk');
 
-    await useListDetailStore.getState().saveItem('item-1', 'Almond Milk', '', 'milk_carton');
-
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'UPDATE_ITEM', itemServerId: 100, name: 'Almond Milk' }),
-      'list-local-1'
-    );
+    expect(saveItemOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+      name: 'Almond Milk',
+      description: '500g',
+      iconKey: 'milk',
+    });
   });
 
-  it('also enqueues UPDATE_ITEM_DESC to sync the per-list description', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: false }));
+  it('updates name, description, iconKey in Zustand state', async () => {
+    await useListDetailStore.getState().saveItem('item-1', 'Almond Milk', '500g', 'milk');
 
-    await useListDetailStore.getState().saveItem('item-1', 'Beef Mince', '500g', 'beef');
-
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', itemServerId: 100, description: '500g' }),
-      'list-local-1'
-    );
+    const item = useListDetailStore.getState().items[0];
+    expect(item.name).toBe('Almond Milk');
+    expect(item.description).toBe('500g');
+    expect(item.iconKey).toBe('milk');
   });
 
-  it('prepends ! to description in UPDATE_ITEM_DESC when item is important', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: 100, isImportant: true }));
-
-    await useListDetailStore.getState().saveItem('item-1', 'Beef Mince', '500g', 'beef');
-
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'UPDATE_ITEM_DESC', description: '!500g' }),
-      'list-local-1'
-    );
-  });
-
-  it('skips enqueue when item has no serverId', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await useListDetailStore.getState().saveItem('item-1', 'New Name', '', null);
-
-    expect(enqueue).not.toHaveBeenCalled();
-  });
-
-  it('updates item in state', async () => {
-    (getItem as jest.Mock).mockResolvedValue(makeItem({ serverId: null }));
-
-    await useListDetailStore.getState().saveItem('item-1', 'Butter', '', 'butter');
-
-    expect(useListDetailStore.getState().items[0].name).toBe('Butter');
-    expect(useListDetailStore.getState().items[0].iconKey).toBe('butter');
+  it('does nothing when no activeLocalId', async () => {
+    useListDetailStore.setState({ activeLocalId: null });
+    await useListDetailStore.getState().saveItem('item-1', 'X', '', null);
+    expect(saveItemOp).not.toHaveBeenCalled();
   });
 });
 
 // ─── addItem ─────────────────────────────────────────────────────────────────
 
 describe('addItem', () => {
-  const newItem = makeItem({ localId: 'new-item', name: 'Bread' });
-
   beforeEach(() => {
     useListDetailStore.setState({ items: [], activeLocalId: 'list-local-1', activeServerId: 5 });
-    (addItemLocally as jest.Mock).mockResolvedValue(newItem);
-    (recordItemUsed as jest.Mock).mockResolvedValue(undefined);
   });
 
-  it('adds item locally, records history, and enqueues ADD_ITEM', async () => {
+  it('calls addItemOp with correct params', async () => {
     await useListDetailStore.getState().addItem('Bread', '', null, 'Other');
 
-    expect(addItemLocally).toHaveBeenCalledWith('list-local-1', 'Bread', '', 'apple', 'Produce');
-    expect(recordItemUsed).toHaveBeenCalled();
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ opType: 'ADD_ITEM', listServerId: 5 }),
-      'list-local-1'
-    );
+    expect(addItemOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      currentItems: [],
+      name: 'Bread',
+      description: '',
+      iconKey: null,
+      category: 'Other',
+    });
+  });
+
+  it('appends new item to state when action=added', async () => {
+    const newItem = makeItem({ localId: 'new-item', name: 'Bread' });
+    (addItemOp as jest.Mock).mockResolvedValue({ action: 'added', item: newItem });
+
+    await useListDetailStore.getState().addItem('Bread', '', null, 'Other');
+
     expect(useListDetailStore.getState().items).toContainEqual(newItem);
   });
 
-  it('skips ADD_ITEM enqueue when list has no serverId', async () => {
-    useListDetailStore.setState({ activeServerId: null });
+  it('updates existing item description in state when action=merged', async () => {
+    const existing = makeItem({ localId: 'item-milk', name: 'Milk', description: '3L' });
+    useListDetailStore.setState({ items: [existing], activeLocalId: 'list-local-1', activeServerId: 5 });
+    (addItemOp as jest.Mock).mockResolvedValue({
+      action: 'merged',
+      item: { ...existing, description: '3L + 2L' },
+    });
 
-    await useListDetailStore.getState().addItem('Bread', '', null, 'Other');
+    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
 
-    expect(addItemLocally).toHaveBeenCalled();
-    expect(enqueue).not.toHaveBeenCalled();
-  });
-
-  it('uses provided iconKey and category instead of matching', async () => {
-    await useListDetailStore.getState().addItem('Banana', '', 'banana', 'Produce');
-
-    expect(addItemLocally).toHaveBeenCalledWith('list-local-1', 'Banana', '', 'banana', 'Produce');
+    expect(useListDetailStore.getState().items[0].description).toBe('3L + 2L');
+    expect(useListDetailStore.getState().items).toHaveLength(1);
   });
 
   it('does nothing when no activeLocalId', async () => {
     useListDetailStore.setState({ activeLocalId: null });
-
     await useListDetailStore.getState().addItem('Bread', '', null, 'Other');
-
-    expect(addItemLocally).not.toHaveBeenCalled();
-  });
-});
-
-// ─── addItem — duplicate merging ──────────────────────────────────────────────
-
-describe('addItem — duplicate merging', () => {
-  const existingItem = makeItem({
-    localId: 'item-milk',
-    serverId: 100,
-    name: 'Milk',
-    description: '3L',
-    isChecked: false,
-    isImportant: false,
-  });
-
-  beforeEach(() => {
-    useListDetailStore.setState({
-      items: [existingItem],
-      activeLocalId: 'list-local-1',
-      activeServerId: 5,
-    });
-    (updateItemDescription as jest.Mock).mockResolvedValue(undefined);
-    (mergeQuantities as jest.Mock).mockImplementation(
-      (existing: string, incoming: string) =>
-        existing && incoming ? `${existing} + ${incoming}` : existing || incoming
-    );
-  });
-
-  it('merges description instead of adding a new item when name matches', async () => {
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(mergeQuantities).toHaveBeenCalledWith('3L', '2L');
-    expect(updateItemDescription).toHaveBeenCalledWith('item-milk', '3L + 2L');
-    expect(addItemLocally).not.toHaveBeenCalled();
-  });
-
-  it('updates store state with merged description', async () => {
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    const { items } = useListDetailStore.getState();
-    expect(items).toHaveLength(1);
-    expect(items[0].description).toBe('3L + 2L');
-  });
-
-  it('enqueues UPDATE_ITEM_DESC when existing item has a serverId', async () => {
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        opType: 'UPDATE_ITEM_DESC',
-        listServerId: 5,
-        itemServerId: 100,
-        description: '3L + 2L',
-      }),
-      'list-local-1'
-    );
-  });
-
-  it('prefixes ! in server description for important items', async () => {
-    useListDetailStore.setState({
-      items: [{ ...existingItem, isImportant: true }],
-    });
-
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        opType: 'UPDATE_ITEM_DESC',
-        description: '!3L + 2L',
-      }),
-      'list-local-1'
-    );
-  });
-
-  it('skips enqueue when existing item has no serverId', async () => {
-    useListDetailStore.setState({
-      items: [{ ...existingItem, serverId: null }],
-    });
-
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(enqueue).not.toHaveBeenCalled();
-    expect(updateItemDescription).toHaveBeenCalled();
-  });
-
-  it('skips enqueue when list has no serverId', async () => {
-    useListDetailStore.setState({ activeServerId: null });
-
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(enqueue).not.toHaveBeenCalled();
-    expect(updateItemDescription).toHaveBeenCalled();
-  });
-
-  it('matches name case-insensitively', async () => {
-    await useListDetailStore.getState().addItem('MILK', '2L', null, 'Dairy');
-
-    expect(mergeQuantities).toHaveBeenCalledWith('3L', '2L');
-    expect(addItemLocally).not.toHaveBeenCalled();
-  });
-
-  it('does not merge with checked items — adds a fresh item', async () => {
-    useListDetailStore.setState({
-      items: [{ ...existingItem, isChecked: true }],
-    });
-    (addItemLocally as jest.Mock).mockResolvedValue(
-      makeItem({ localId: 'new-item', name: 'Milk', description: '2L' })
-    );
-
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(addItemLocally).toHaveBeenCalled();
-    expect(updateItemDescription).not.toHaveBeenCalled();
-  });
-
-  it('does not merge with soft-deleted items — adds a fresh item', async () => {
-    useListDetailStore.setState({
-      items: [{ ...existingItem, isDeleted: true }],
-    });
-    (addItemLocally as jest.Mock).mockResolvedValue(
-      makeItem({ localId: 'new-item', name: 'Milk', description: '2L' })
-    );
-
-    await useListDetailStore.getState().addItem('Milk', '2L', null, 'Dairy');
-
-    expect(addItemLocally).toHaveBeenCalled();
-    expect(updateItemDescription).not.toHaveBeenCalled();
+    expect(addItemOp).not.toHaveBeenCalled();
   });
 });
 
@@ -673,5 +540,61 @@ describe('clearTrolley', () => {
   it('does nothing when no activeLocalId', async () => {
     await useListDetailStore.getState().clearTrolley();
     expect(clearCheckedItems).not.toHaveBeenCalled();
+  });
+});
+
+// ─── moveItemToCategory ───────────────────────────────────────────────────────
+
+describe('moveItemToCategory', () => {
+  const dairyCategory = { id: 9, name: 'Dairy', ordering: 1 };
+
+  beforeEach(() => {
+    useListDetailStore.setState({
+      items: [makeItem()],
+      activeLocalId: 'list-local-1',
+      activeServerId: 5,
+      allCategories: [dairyCategory],
+    });
+  });
+
+  it('calls moveItemToCategoryOp with resolved category', async () => {
+    await useListDetailStore.getState().moveItemToCategory('item-1', 9);
+
+    expect(moveItemToCategoryOp).toHaveBeenCalledWith({
+      listContext: { activeLocalId: 'list-local-1', activeServerId: 5 },
+      itemLocalId: 'item-1',
+      category: dairyCategory,
+    });
+  });
+
+  it('calls moveItemToCategoryOp with null when categoryId is null', async () => {
+    await useListDetailStore.getState().moveItemToCategory('item-1', null);
+
+    expect(moveItemToCategoryOp).toHaveBeenCalledWith(
+      expect.objectContaining({ category: null })
+    );
+  });
+
+  it('updates category fields in Zustand state', async () => {
+    await useListDetailStore.getState().moveItemToCategory('item-1', 9);
+
+    const item = useListDetailStore.getState().items[0];
+    expect(item.category).toBe('Dairy');
+    expect(item.serverCategoryId).toBe(9);
+    expect(item.isDirty).toBe(true);
+  });
+
+  it('sets Uncategorized when categoryId is null', async () => {
+    await useListDetailStore.getState().moveItemToCategory('item-1', null);
+
+    const item = useListDetailStore.getState().items[0];
+    expect(item.category).toBe('Uncategorized');
+    expect(item.serverCategoryId).toBeNull();
+  });
+
+  it('does nothing when no activeLocalId', async () => {
+    useListDetailStore.setState({ activeLocalId: null });
+    await useListDetailStore.getState().moveItemToCategory('item-1', 9);
+    expect(moveItemToCategoryOp).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/utils/generateServerDescription.test.ts
+++ b/src/__tests__/utils/generateServerDescription.test.ts
@@ -1,0 +1,16 @@
+import { generateServerDescription } from '@/utils/generateServerDescription';
+
+describe('generateServerDescription', () => {
+  it('returns the description unchanged when not important', () => {
+    expect(generateServerDescription('2L', false)).toBe('2L');
+  });
+
+  it('prepends ! when important', () => {
+    expect(generateServerDescription('2L', true)).toBe('!2L');
+  });
+
+  it('handles empty description', () => {
+    expect(generateServerDescription('', false)).toBe('');
+    expect(generateServerDescription('', true)).toBe('!');
+  });
+});

--- a/src/__tests__/utils/generateServerDescription.test.ts
+++ b/src/__tests__/utils/generateServerDescription.test.ts
@@ -1,16 +1,39 @@
 import { generateServerDescription } from '@/utils/generateServerDescription';
+import type { LocalItem } from '@/db/items';
+
+function makeItem(overrides: Partial<LocalItem> = {}): LocalItem {
+  return {
+    localId: 'item-1',
+    serverId: null,
+    listLocalId: 'list-1',
+    name: 'Milk',
+    description: '2L',
+    iconKey: null,
+    category: 'Dairy',
+    serverCategoryId: null,
+    serverCategoryName: null,
+    serverCategoryOrdering: null,
+    isChecked: false,
+    isImportant: false,
+    isDirty: false,
+    isDeleted: false,
+    createdAt: 0,
+    checkedAt: null,
+    ...overrides,
+  };
+}
 
 describe('generateServerDescription', () => {
   it('returns the description unchanged when not important', () => {
-    expect(generateServerDescription('2L', false)).toBe('2L');
+    expect(generateServerDescription(makeItem({ description: '2L', isImportant: false }))).toBe('2L');
   });
 
   it('prepends ! when important', () => {
-    expect(generateServerDescription('2L', true)).toBe('!2L');
+    expect(generateServerDescription(makeItem({ description: '2L', isImportant: true }))).toBe('!2L');
   });
 
   it('handles empty description', () => {
-    expect(generateServerDescription('', false)).toBe('');
-    expect(generateServerDescription('', true)).toBe('!');
+    expect(generateServerDescription(makeItem({ description: '', isImportant: false }))).toBe('');
+    expect(generateServerDescription(makeItem({ description: '', isImportant: true }))).toBe('!');
   });
 });

--- a/src/db/items.ts
+++ b/src/db/items.ts
@@ -300,7 +300,7 @@ export async function clearExpiredCheckedItems(
 
 export async function toggleItemImportant(localId: string, important: boolean): Promise<void> {
   const db = await getDb();
-  await db.runAsync('UPDATE local_items SET is_important = ? WHERE local_id = ?', [
+  await db.runAsync('UPDATE local_items SET is_important = ?, is_dirty = 1 WHERE local_id = ?', [
     important ? 1 : 0,
     localId,
   ]);

--- a/src/items/itemOperations.ts
+++ b/src/items/itemOperations.ts
@@ -8,13 +8,13 @@ import {
   updateItemDescription,
   updateItemNameAndIcon,
   updateItemCategory,
-  getItem,
 } from '@/db/items';
 import type { LocalItem } from '@/db/items';
 import { enqueue, removePendingCheckItem } from '@/sync/syncManager';
 import { matchItem } from '@/data/foodMatcher';
 import { mergeQuantities } from '@/utils/mergeQuantities';
 import { recordItemUsed } from '@/db/history';
+import { generateServerDescription } from '@/utils/generateServerDescription';
 import type { HouseholdCategory } from '@/api/households';
 
 type ListContext = { activeLocalId: string; activeServerId: number | null };
@@ -39,16 +39,13 @@ export async function addItem(params: {
     const mergedDescription = mergeQuantities(existing.description, description);
     await updateItemDescription(existing.localId, mergedDescription);
     if (existing.serverId !== null && activeServerId !== null) {
-      const serverDescription = existing.isImportant
-        ? `!${mergedDescription}`
-        : mergedDescription;
       await enqueue(
         {
           opType: 'UPDATE_ITEM_DESC',
           listServerId: activeServerId,
           itemServerId: existing.serverId,
           itemLocalId: existing.localId,
-          description: serverDescription,
+          description: generateServerDescription(mergedDescription, existing.isImportant),
         },
         activeLocalId
       );
@@ -83,157 +80,130 @@ export async function addItem(params: {
 
 export async function checkItem(params: {
   listContext: ListContext;
-  itemLocalId: string;
-}): Promise<{ checkedAt: number }> {
-  const { listContext, itemLocalId } = params;
+  item: LocalItem;
+}): Promise<LocalItem> {
+  const { listContext, item } = params;
   const { activeLocalId, activeServerId } = listContext;
 
   const checkedAt = Date.now();
-  await checkItemDb(itemLocalId, checkedAt);
-  const freshItem = await getItem(itemLocalId);
-  if (
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null
-  ) {
+  await checkItemDb(item.localId, checkedAt);
+  if (item.serverId !== null && activeServerId !== null) {
     await enqueue(
       {
         opType: 'CHECK_ITEM',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
         removedAt: checkedAt,
       },
       activeLocalId
     );
   }
-  return { checkedAt };
+  return { ...item, isChecked: true, isDirty: true, checkedAt };
 }
 
 export async function uncheckItem(params: {
   listContext: ListContext;
-  itemLocalId: string;
-}): Promise<{ needsReAdd: boolean }> {
-  const { listContext, itemLocalId } = params;
+  item: LocalItem;
+}): Promise<LocalItem> {
+  const { listContext, item } = params;
   const { activeLocalId, activeServerId } = listContext;
 
-  const hadPendingOp = await removePendingCheckItem(itemLocalId);
-  const freshItem = await getItem(itemLocalId);
-  const needsReAdd =
-    !hadPendingOp &&
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null;
+  const hadPendingOp = await removePendingCheckItem(item.localId);
+  const needsReAdd = !hadPendingOp && item.serverId !== null && activeServerId !== null;
 
-  await uncheckItemDb(itemLocalId, needsReAdd);
+  await uncheckItemDb(item.localId, needsReAdd);
 
-  if (needsReAdd && freshItem && activeServerId !== null) {
+  if (needsReAdd && activeServerId !== null) {
     await enqueue(
       {
         opType: 'ADD_ITEM',
         listServerId: activeServerId,
         listLocalId: activeLocalId,
-        itemLocalId,
-        name: freshItem.name,
-        description: freshItem.description,
+        itemLocalId: item.localId,
+        name: item.name,
+        description: item.description,
       },
       activeLocalId
     );
   }
-  return { needsReAdd };
+  return { ...item, isChecked: false, isDirty: needsReAdd, checkedAt: null };
 }
 
 export async function toggleImportant(params: {
   listContext: ListContext;
-  itemLocalId: string;
-  currentIsImportant: boolean;
-}): Promise<void> {
-  const { listContext, itemLocalId, currentIsImportant } = params;
+  item: LocalItem;
+}): Promise<LocalItem> {
+  const { listContext, item } = params;
   const { activeLocalId, activeServerId } = listContext;
 
-  await toggleItemImportant(itemLocalId, !currentIsImportant);
-  const freshItem = await getItem(itemLocalId);
-  if (
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null
-  ) {
-    const serverDescription = freshItem.isImportant
-      ? `!${freshItem.description}`
-      : freshItem.description;
+  const newIsImportant = !item.isImportant;
+  await toggleItemImportant(item.localId, newIsImportant);
+  if (item.serverId !== null && activeServerId !== null) {
     await enqueue(
       {
         opType: 'UPDATE_ITEM_DESC',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
-        description: serverDescription,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
+        description: generateServerDescription(item.description, newIsImportant),
       },
       activeLocalId
     );
   }
+  return { ...item, isImportant: newIsImportant };
 }
 
 export async function deleteItem(params: {
   listContext: ListContext;
-  itemLocalId: string;
+  item: LocalItem;
 }): Promise<void> {
-  const { listContext, itemLocalId } = params;
+  const { listContext, item } = params;
   const { activeLocalId, activeServerId } = listContext;
 
-  await softDeleteItem(itemLocalId);
-  const freshItem = await getItem(itemLocalId);
-  if (
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null
-  ) {
+  await softDeleteItem(item.localId);
+  if (item.serverId !== null && activeServerId !== null) {
     await enqueue(
       {
         opType: 'REMOVE_ITEM',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
         removedAt: Date.now(),
       },
       activeLocalId
     );
   } else {
-    await hardDeleteItem(itemLocalId);
+    await hardDeleteItem(item.localId);
   }
 }
 
 export async function saveItem(params: {
   listContext: ListContext;
-  itemLocalId: string;
+  item: LocalItem;
   name: string;
   description: string;
   iconKey: string | null;
-}): Promise<void> {
-  const { listContext, itemLocalId, name, description, iconKey } = params;
+}): Promise<LocalItem> {
+  const { listContext, item, name, description, iconKey } = params;
   const { activeLocalId, activeServerId } = listContext;
 
-  await updateItemNameAndIcon(itemLocalId, name, description, iconKey);
-  const freshItem = await getItem(itemLocalId);
-  if (
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null
-  ) {
+  await updateItemNameAndIcon(item.localId, name, description, iconKey);
+  if (item.serverId !== null && activeServerId !== null) {
     const category =
-      freshItem.serverCategoryId !== null
+      item.serverCategoryId !== null
         ? {
-            id: freshItem.serverCategoryId,
-            name: freshItem.serverCategoryName ?? '',
-            ordering: freshItem.serverCategoryOrdering ?? 0,
+            id: item.serverCategoryId,
+            name: item.serverCategoryName ?? '',
+            ordering: item.serverCategoryOrdering ?? 0,
           }
         : null;
     await enqueue(
       {
         opType: 'UPDATE_ITEM',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
         name,
         description,
         iconKey,
@@ -241,26 +211,26 @@ export async function saveItem(params: {
       },
       activeLocalId
     );
-    const serverDescription = freshItem.isImportant ? `!${description}` : description;
     await enqueue(
       {
         opType: 'UPDATE_ITEM_DESC',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
-        description: serverDescription,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
+        description: generateServerDescription(description, item.isImportant),
       },
       activeLocalId
     );
   }
+  return { ...item, name, description, iconKey };
 }
 
 export async function moveItemToCategory(params: {
   listContext: ListContext;
-  itemLocalId: string;
+  item: LocalItem;
   category: HouseholdCategory | null;
-}): Promise<void> {
-  const { listContext, itemLocalId, category } = params;
+}): Promise<LocalItem> {
+  const { listContext, item, category } = params;
   const { activeLocalId, activeServerId } = listContext;
 
   const categoryName = category?.name ?? 'Uncategorized';
@@ -269,18 +239,13 @@ export async function moveItemToCategory(params: {
   const serverCategoryOrdering = category?.ordering ?? null;
 
   await updateItemCategory(
-    itemLocalId,
+    item.localId,
     categoryName,
     serverCategoryId,
     serverCategoryName,
     serverCategoryOrdering
   );
-  const freshItem = await getItem(itemLocalId);
-  if (
-    freshItem?.serverId !== null &&
-    freshItem?.serverId !== undefined &&
-    activeServerId !== null
-  ) {
+  if (item.serverId !== null && activeServerId !== null) {
     const serverCategory = category
       ? { id: category.id, name: category.name, ordering: category.ordering }
       : null;
@@ -288,14 +253,22 @@ export async function moveItemToCategory(params: {
       {
         opType: 'UPDATE_ITEM',
         listServerId: activeServerId,
-        itemServerId: freshItem.serverId,
-        itemLocalId,
-        name: freshItem.name,
-        description: freshItem.description,
-        iconKey: freshItem.iconKey,
+        itemServerId: item.serverId,
+        itemLocalId: item.localId,
+        name: item.name,
+        description: item.description,
+        iconKey: item.iconKey,
         category: serverCategory,
       },
       activeLocalId
     );
   }
+  return {
+    ...item,
+    category: categoryName,
+    serverCategoryId,
+    serverCategoryName,
+    serverCategoryOrdering,
+    isDirty: true,
+  };
 }

--- a/src/items/itemOperations.ts
+++ b/src/items/itemOperations.ts
@@ -45,7 +45,7 @@ export async function addItem(params: {
           listServerId: activeServerId,
           itemServerId: existing.serverId,
           itemLocalId: existing.localId,
-          description: generateServerDescription(mergedDescription, existing.isImportant),
+          description: generateServerDescription({ ...existing, description: mergedDescription }),
         },
         activeLocalId
       );
@@ -146,7 +146,7 @@ export async function toggleImportant(params: {
         listServerId: activeServerId,
         itemServerId: item.serverId,
         itemLocalId: item.localId,
-        description: generateServerDescription(item.description, newIsImportant),
+        description: generateServerDescription({ ...item, isImportant: newIsImportant }),
       },
       activeLocalId
     );
@@ -217,7 +217,7 @@ export async function saveItem(params: {
         listServerId: activeServerId,
         itemServerId: item.serverId,
         itemLocalId: item.localId,
-        description: generateServerDescription(description, item.isImportant),
+        description: generateServerDescription({ ...item, description }),
       },
       activeLocalId
     );

--- a/src/items/itemOperations.ts
+++ b/src/items/itemOperations.ts
@@ -1,0 +1,301 @@
+import {
+  addItemLocally,
+  softDeleteItem,
+  hardDeleteItem,
+  checkItem as checkItemDb,
+  uncheckItem as uncheckItemDb,
+  toggleItemImportant,
+  updateItemDescription,
+  updateItemNameAndIcon,
+  updateItemCategory,
+  getItem,
+} from '@/db/items';
+import type { LocalItem } from '@/db/items';
+import { enqueue, removePendingCheckItem } from '@/sync/syncManager';
+import { matchItem } from '@/data/foodMatcher';
+import { mergeQuantities } from '@/utils/mergeQuantities';
+import { recordItemUsed } from '@/db/history';
+import type { HouseholdCategory } from '@/api/households';
+
+type ListContext = { activeLocalId: string; activeServerId: number | null };
+
+export async function addItem(params: {
+  listContext: ListContext;
+  currentItems: LocalItem[];
+  name: string;
+  description: string;
+  iconKey: string | null;
+  category: string;
+}): Promise<{ action: 'added'; item: LocalItem } | { action: 'merged'; item: LocalItem }> {
+  const { listContext, currentItems, name, description, iconKey, category } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  const nameLower = name.trim().toLowerCase();
+  const existing = currentItems.find(
+    (i) => !i.isChecked && !i.isDeleted && i.name.toLowerCase() === nameLower
+  );
+
+  if (existing !== undefined) {
+    const mergedDescription = mergeQuantities(existing.description, description);
+    await updateItemDescription(existing.localId, mergedDescription);
+    if (existing.serverId !== null && activeServerId !== null) {
+      const serverDescription = existing.isImportant
+        ? `!${mergedDescription}`
+        : mergedDescription;
+      await enqueue(
+        {
+          opType: 'UPDATE_ITEM_DESC',
+          listServerId: activeServerId,
+          itemServerId: existing.serverId,
+          itemLocalId: existing.localId,
+          description: serverDescription,
+        },
+        activeLocalId
+      );
+    }
+    return { action: 'merged', item: { ...existing, description: mergedDescription } };
+  }
+
+  const match = iconKey ? { iconKey, category } : matchItem(name);
+  const newItem = await addItemLocally(
+    activeLocalId,
+    name,
+    description,
+    match.iconKey,
+    match.category
+  );
+  await recordItemUsed(name, match.iconKey, match.category);
+  if (activeServerId !== null) {
+    await enqueue(
+      {
+        opType: 'ADD_ITEM',
+        listServerId: activeServerId,
+        listLocalId: activeLocalId,
+        itemLocalId: newItem.localId,
+        name,
+        description,
+      },
+      activeLocalId
+    );
+  }
+  return { action: 'added', item: newItem };
+}
+
+export async function checkItem(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+}): Promise<{ checkedAt: number }> {
+  const { listContext, itemLocalId } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  const checkedAt = Date.now();
+  await checkItemDb(itemLocalId, checkedAt);
+  const freshItem = await getItem(itemLocalId);
+  if (
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null
+  ) {
+    await enqueue(
+      {
+        opType: 'CHECK_ITEM',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        removedAt: checkedAt,
+      },
+      activeLocalId
+    );
+  }
+  return { checkedAt };
+}
+
+export async function uncheckItem(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+}): Promise<{ needsReAdd: boolean }> {
+  const { listContext, itemLocalId } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  const hadPendingOp = await removePendingCheckItem(itemLocalId);
+  const freshItem = await getItem(itemLocalId);
+  const needsReAdd =
+    !hadPendingOp &&
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null;
+
+  await uncheckItemDb(itemLocalId, needsReAdd);
+
+  if (needsReAdd && freshItem && activeServerId !== null) {
+    await enqueue(
+      {
+        opType: 'ADD_ITEM',
+        listServerId: activeServerId,
+        listLocalId: activeLocalId,
+        itemLocalId,
+        name: freshItem.name,
+        description: freshItem.description,
+      },
+      activeLocalId
+    );
+  }
+  return { needsReAdd };
+}
+
+export async function toggleImportant(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+  currentIsImportant: boolean;
+}): Promise<void> {
+  const { listContext, itemLocalId, currentIsImportant } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  await toggleItemImportant(itemLocalId, !currentIsImportant);
+  const freshItem = await getItem(itemLocalId);
+  if (
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null
+  ) {
+    const serverDescription = freshItem.isImportant
+      ? `!${freshItem.description}`
+      : freshItem.description;
+    await enqueue(
+      {
+        opType: 'UPDATE_ITEM_DESC',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        description: serverDescription,
+      },
+      activeLocalId
+    );
+  }
+}
+
+export async function deleteItem(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+}): Promise<void> {
+  const { listContext, itemLocalId } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  await softDeleteItem(itemLocalId);
+  const freshItem = await getItem(itemLocalId);
+  if (
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null
+  ) {
+    await enqueue(
+      {
+        opType: 'REMOVE_ITEM',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        removedAt: Date.now(),
+      },
+      activeLocalId
+    );
+  } else {
+    await hardDeleteItem(itemLocalId);
+  }
+}
+
+export async function saveItem(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+  name: string;
+  description: string;
+  iconKey: string | null;
+}): Promise<void> {
+  const { listContext, itemLocalId, name, description, iconKey } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  await updateItemNameAndIcon(itemLocalId, name, description, iconKey);
+  const freshItem = await getItem(itemLocalId);
+  if (
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null
+  ) {
+    const category =
+      freshItem.serverCategoryId !== null
+        ? {
+            id: freshItem.serverCategoryId,
+            name: freshItem.serverCategoryName ?? '',
+            ordering: freshItem.serverCategoryOrdering ?? 0,
+          }
+        : null;
+    await enqueue(
+      {
+        opType: 'UPDATE_ITEM',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        name,
+        description,
+        iconKey,
+        category,
+      },
+      activeLocalId
+    );
+    const serverDescription = freshItem.isImportant ? `!${description}` : description;
+    await enqueue(
+      {
+        opType: 'UPDATE_ITEM_DESC',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        description: serverDescription,
+      },
+      activeLocalId
+    );
+  }
+}
+
+export async function moveItemToCategory(params: {
+  listContext: ListContext;
+  itemLocalId: string;
+  category: HouseholdCategory | null;
+}): Promise<void> {
+  const { listContext, itemLocalId, category } = params;
+  const { activeLocalId, activeServerId } = listContext;
+
+  const categoryName = category?.name ?? 'Uncategorized';
+  const serverCategoryId = category?.id ?? null;
+  const serverCategoryName = category?.name ?? null;
+  const serverCategoryOrdering = category?.ordering ?? null;
+
+  await updateItemCategory(
+    itemLocalId,
+    categoryName,
+    serverCategoryId,
+    serverCategoryName,
+    serverCategoryOrdering
+  );
+  const freshItem = await getItem(itemLocalId);
+  if (
+    freshItem?.serverId !== null &&
+    freshItem?.serverId !== undefined &&
+    activeServerId !== null
+  ) {
+    const serverCategory = category
+      ? { id: category.id, name: category.name, ordering: category.ordering }
+      : null;
+    await enqueue(
+      {
+        opType: 'UPDATE_ITEM',
+        listServerId: activeServerId,
+        itemServerId: freshItem.serverId,
+        itemLocalId,
+        name: freshItem.name,
+        description: freshItem.description,
+        iconKey: freshItem.iconKey,
+        category: serverCategory,
+      },
+      activeLocalId
+    );
+  }
+}

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -320,15 +320,11 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
         iconKey,
         category,
       });
-      if (result.action === 'added') {
-        set({ items: [...items, result.item] });
-      } else {
-        set({
-          items: items.map((i) =>
-            i.localId === result.item.localId ? { ...i, description: result.item.description } : i
-          ),
-        });
+      if (result.action === 'merged') {
+        set({ items: items.map((i) => (i.localId === result.item.localId ? result.item : i)) });
+        return;
       }
+      set({ items: [...items, result.item] });
     },
 
     clearTrolley: async () => {

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -7,7 +7,6 @@ import {
   upsertItemFromServer,
   removeItemsDeletedOnServer,
   clearCheckedItems,
-  getItem,
 } from '@/db/items';
 import { getAllLists, upsertListFromServer } from '@/db/lists';
 import { useAuthStore } from '@/store/authStore';

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -6,28 +6,25 @@ import {
   getItemsForList,
   upsertItemFromServer,
   removeItemsDeletedOnServer,
-  checkItem,
-  uncheckItem,
   clearCheckedItems,
-  toggleItemImportant,
-  updateItemNameAndIcon,
-  updateItemDescription,
-  addItemLocally,
-  softDeleteItem,
-  hardDeleteItem,
   getItem,
-  updateItemCategory,
 } from '@/db/items';
 import { getAllLists, upsertListFromServer } from '@/db/lists';
-import { enqueue as syncManagerEnqueue, removePendingCheckItem } from '@/sync/syncManager';
 import { useAuthStore } from '@/store/authStore';
 import { matchItem } from '@/data/foodMatcher';
-import { mergeQuantities } from '@/utils/mergeQuantities';
-import { recordItemUsed } from '@/db/history';
 import { SECURE_STORE_KEYS } from '@/utils/constants';
 import type { LocalItem } from '@/db/items';
 import type { LocalList } from '@/db/lists';
 import type { HouseholdCategory } from '@/api/households';
+import {
+  addItem as addItemOp,
+  checkItem as checkItemOp,
+  uncheckItem as uncheckItemOp,
+  toggleImportant as toggleImportantOp,
+  deleteItem as deleteItemOp,
+  saveItem as saveItemOp,
+  moveItemToCategory as moveItemToCategoryOp,
+} from '@/items/itemOperations';
 
 // ─── State shape ─────────────────────────────────────────────────────────────
 
@@ -249,67 +246,26 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
     toggleDone: async (localId) => {
       const { items, activeLocalId, activeServerId } = get();
       const item = items.find((i) => i.localId === localId);
-      if (!item) {
+      if (!item || !activeLocalId) {
         return;
       }
+      const listContext = { activeLocalId, activeServerId };
 
       if (!item.isChecked) {
-        // ── Checking off: move into trolley, remove from server list ──────────
-        const checkedAt = Date.now();
-        await checkItem(localId, checkedAt);
-        const freshItem = await getItem(localId);
-        if (
-          freshItem?.serverId !== null &&
-          freshItem?.serverId !== undefined &&
-          activeServerId !== null &&
-          activeLocalId !== null
-        ) {
-          await syncManagerEnqueue(
-            {
-              opType: 'CHECK_ITEM',
-              listServerId: activeServerId,
-              itemServerId: freshItem.serverId,
-              itemLocalId: localId,
-              removedAt: checkedAt,
-            },
-            activeLocalId
-          );
-        }
-        set({
-          items: items.map((i) =>
-            i.localId === localId ? { ...i, isChecked: true, isDirty: true, checkedAt } : i
-          ),
-        });
-      } else {
-        // ── Unchecking: return item to active list ────────────────────────────
-        const hadPendingOp = await removePendingCheckItem(localId);
-        const freshItem = await getItem(localId);
-        const needsReAdd =
-          !hadPendingOp &&
-          freshItem?.serverId !== null &&
-          freshItem?.serverId !== undefined &&
-          activeServerId !== null &&
-          activeLocalId !== null;
-
-        await uncheckItem(localId, needsReAdd);
-
-        if (needsReAdd && freshItem && activeServerId !== null && activeLocalId !== null) {
-          await syncManagerEnqueue(
-            {
-              opType: 'ADD_ITEM',
-              listServerId: activeServerId,
-              listLocalId: activeLocalId,
-              itemLocalId: localId,
-              name: freshItem.name,
-              description: freshItem.description,
-            },
-            activeLocalId
-          );
-        }
+        const result = await checkItemOp({ listContext, itemLocalId: localId });
         set({
           items: items.map((i) =>
             i.localId === localId
-              ? { ...i, isChecked: false, isDirty: needsReAdd, checkedAt: null }
+              ? { ...i, isChecked: true, isDirty: true, checkedAt: result.checkedAt }
+              : i
+          ),
+        });
+      } else {
+        const result = await uncheckItemOp({ listContext, itemLocalId: localId });
+        set({
+          items: items.map((i) =>
+            i.localId === localId
+              ? { ...i, isChecked: false, isDirty: result.needsReAdd, checkedAt: null }
               : i
           ),
         });
@@ -319,108 +275,45 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
     toggleImportant: async (localId) => {
       const { items, activeLocalId, activeServerId } = get();
       const item = items.find((i) => i.localId === localId);
-      if (!item) {
+      if (!item || !activeLocalId) {
         return;
       }
-      const isImportant = item.isImportant;
-      await toggleItemImportant(localId, !isImportant);
-      const freshItem = await getItem(localId);
-      if (
-        freshItem?.serverId !== null &&
-        freshItem?.serverId !== undefined &&
-        activeServerId !== null &&
-        activeLocalId !== null
-      ) {
-        const serverDescription = freshItem.isImportant
-          ? `!${freshItem.description}`
-          : freshItem.description;
-        await syncManagerEnqueue(
-          {
-            opType: 'UPDATE_ITEM_DESC',
-            listServerId: activeServerId,
-            itemServerId: freshItem.serverId,
-            itemLocalId: localId,
-            description: serverDescription,
-          },
-          activeLocalId
-        );
-      }
+      await toggleImportantOp({
+        listContext: { activeLocalId, activeServerId },
+        itemLocalId: localId,
+        currentIsImportant: item.isImportant,
+      });
       set({
-        items: items.map((i) => (i.localId === localId ? { ...i, isImportant: !isImportant } : i)),
+        items: items.map((i) =>
+          i.localId === localId ? { ...i, isImportant: !item.isImportant } : i
+        ),
       });
     },
 
     deleteItem: async (localId) => {
       const { activeLocalId, activeServerId, items } = get();
-      await softDeleteItem(localId);
-      const freshItem = await getItem(localId);
-      if (
-        freshItem?.serverId !== null &&
-        freshItem?.serverId !== undefined &&
-        activeServerId !== null &&
-        activeLocalId !== null
-      ) {
-        await syncManagerEnqueue(
-          {
-            opType: 'REMOVE_ITEM',
-            listServerId: activeServerId,
-            itemServerId: freshItem.serverId,
-            itemLocalId: localId,
-            removedAt: Date.now(),
-          },
-          activeLocalId
-        );
-      } else {
-        await hardDeleteItem(localId);
+      if (!activeLocalId) {
+        return;
       }
+      await deleteItemOp({
+        listContext: { activeLocalId, activeServerId },
+        itemLocalId: localId,
+      });
       set({ items: items.filter((i) => i.localId !== localId) });
     },
 
     saveItem: async (localId, name, description, iconKey) => {
       const { activeLocalId, activeServerId, items } = get();
-      await updateItemNameAndIcon(localId, name, description, iconKey);
-      const freshItem = await getItem(localId);
-      if (
-        freshItem?.serverId !== null &&
-        freshItem?.serverId !== undefined &&
-        activeServerId !== null &&
-        activeLocalId !== null
-      ) {
-        const category =
-          freshItem.serverCategoryId !== null
-            ? {
-                id: freshItem.serverCategoryId,
-                name: freshItem.serverCategoryName ?? '',
-                ordering: freshItem.serverCategoryOrdering ?? 0,
-              }
-            : null;
-        await syncManagerEnqueue(
-          {
-            opType: 'UPDATE_ITEM',
-            listServerId: activeServerId,
-            itemServerId: freshItem.serverId,
-            itemLocalId: localId,
-            name,
-            description,
-            iconKey,
-            category,
-          },
-          activeLocalId
-        );
-        // description is a per-list-instance field; the catalog endpoint (UPDATE_ITEM) does not
-        // persist it to the shoppinglist. Sync via the dedicated per-list endpoint as well.
-        const serverDescription = freshItem.isImportant ? `!${description}` : description;
-        await syncManagerEnqueue(
-          {
-            opType: 'UPDATE_ITEM_DESC',
-            listServerId: activeServerId,
-            itemServerId: freshItem.serverId,
-            itemLocalId: localId,
-            description: serverDescription,
-          },
-          activeLocalId
-        );
+      if (!activeLocalId) {
+        return;
       }
+      await saveItemOp({
+        listContext: { activeLocalId, activeServerId },
+        itemLocalId: localId,
+        name,
+        description,
+        iconKey,
+      });
       set({
         items: items.map((i) => (i.localId === localId ? { ...i, name, description, iconKey } : i)),
       });
@@ -431,63 +324,23 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       if (!activeLocalId) {
         return;
       }
-
-      // If a non-checked, non-deleted item with the same name already exists,
-      // merge the quantities rather than inserting a duplicate row.
-      const nameLower = name.trim().toLowerCase();
-      const existing = items.find(
-        (i) => !i.isChecked && !i.isDeleted && i.name.toLowerCase() === nameLower
-      );
-
-      if (existing !== undefined) {
-        const mergedDescription = mergeQuantities(existing.description, description);
-        await updateItemDescription(existing.localId, mergedDescription);
-        if (existing.serverId !== null && activeServerId !== null) {
-          const serverDescription = existing.isImportant
-            ? `!${mergedDescription}`
-            : mergedDescription;
-          await syncManagerEnqueue(
-            {
-              opType: 'UPDATE_ITEM_DESC',
-              listServerId: activeServerId,
-              itemServerId: existing.serverId,
-              itemLocalId: existing.localId,
-              description: serverDescription,
-            },
-            activeLocalId
-          );
-        }
-        set({
-          items: items.map((i) =>
-            i.localId === existing.localId ? { ...i, description: mergedDescription } : i
-          ),
-        });
-        return;
-      }
-
-      const match = iconKey ? { iconKey, category } : matchItem(name);
-      const newItem = await addItemLocally(
-        activeLocalId,
+      const result = await addItemOp({
+        listContext: { activeLocalId, activeServerId },
+        currentItems: items,
         name,
         description,
-        match.iconKey,
-        match.category
-      );
-      await recordItemUsed(name, match.iconKey, match.category);
-      if (activeServerId !== null) {
-        await syncManagerEnqueue(
-          {
-            opType: 'ADD_ITEM',
-            listServerId: activeServerId,
-            listLocalId: activeLocalId,
-            itemLocalId: newItem.localId,
-            name,
-            description,
-          },
-          activeLocalId
-        );
+        iconKey,
+        category,
+      });
+      if (result.action === 'added') {
+        set({ items: [...items, result.item] });
+      } else {
+        set({
+          items: items.map((i) =>
+            i.localId === result.item.localId ? { ...i, description: result.item.description } : i
+          ),
+        });
       }
-      set({ items: [...items, newItem] });
     },
 
     clearTrolley: async () => {
@@ -515,50 +368,27 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
 
     moveItemToCategory: async (localId, categoryId) => {
       const { activeLocalId, activeServerId, items, allCategories } = get();
+      if (!activeLocalId) {
+        return;
+      }
       const category =
         categoryId !== null ? (allCategories.find((c) => c.id === categoryId) ?? null) : null;
 
-      const newName = category?.name ?? 'Uncategorized';
-      const newId = category?.id ?? null;
-      const newCategoryName = category?.name ?? null;
-      const newOrdering = category?.ordering ?? null;
-
-      await updateItemCategory(localId, newName, newId, newCategoryName, newOrdering);
-
-      const freshItem = await getItem(localId);
-      if (
-        freshItem?.serverId !== null &&
-        freshItem?.serverId !== undefined &&
-        activeServerId !== null &&
-        activeLocalId !== null
-      ) {
-        const serverCategory = category
-          ? { id: category.id, name: category.name, ordering: category.ordering }
-          : null;
-        await syncManagerEnqueue(
-          {
-            opType: 'UPDATE_ITEM',
-            listServerId: activeServerId,
-            itemServerId: freshItem.serverId,
-            itemLocalId: localId,
-            name: freshItem.name,
-            description: freshItem.description,
-            iconKey: freshItem.iconKey,
-            category: serverCategory,
-          },
-          activeLocalId
-        );
-      }
+      await moveItemToCategoryOp({
+        listContext: { activeLocalId, activeServerId },
+        itemLocalId: localId,
+        category,
+      });
 
       set({
         items: items.map((i) =>
           i.localId === localId
             ? {
                 ...i,
-                category: newName,
-                serverCategoryId: newId,
-                serverCategoryName: newCategoryName,
-                serverCategoryOrdering: newOrdering,
+                category: category?.name ?? 'Uncategorized',
+                serverCategoryId: category?.id ?? null,
+                serverCategoryName: category?.name ?? null,
+                serverCategoryOrdering: category?.ordering ?? null,
                 isDirty: true,
               }
             : i

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -251,23 +251,11 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       const listContext = { activeLocalId, activeServerId };
 
       if (!item.isChecked) {
-        const result = await checkItemOp({ listContext, itemLocalId: localId });
-        set({
-          items: items.map((i) =>
-            i.localId === localId
-              ? { ...i, isChecked: true, isDirty: true, checkedAt: result.checkedAt }
-              : i
-          ),
-        });
+        const updated = await checkItemOp({ listContext, item });
+        set({ items: items.map((i) => (i.localId === localId ? updated : i)) });
       } else {
-        const result = await uncheckItemOp({ listContext, itemLocalId: localId });
-        set({
-          items: items.map((i) =>
-            i.localId === localId
-              ? { ...i, isChecked: false, isDirty: result.needsReAdd, checkedAt: null }
-              : i
-          ),
-        });
+        const updated = await uncheckItemOp({ listContext, item });
+        set({ items: items.map((i) => (i.localId === localId ? updated : i)) });
       }
     },
 
@@ -277,16 +265,11 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       if (!item || !activeLocalId) {
         return;
       }
-      await toggleImportantOp({
+      const updated = await toggleImportantOp({
         listContext: { activeLocalId, activeServerId },
-        itemLocalId: localId,
-        currentIsImportant: item.isImportant,
+        item,
       });
-      set({
-        items: items.map((i) =>
-          i.localId === localId ? { ...i, isImportant: !item.isImportant } : i
-        ),
-      });
+      set({ items: items.map((i) => (i.localId === localId ? updated : i)) });
     },
 
     deleteItem: async (localId) => {
@@ -294,9 +277,13 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       if (!activeLocalId) {
         return;
       }
+      const item = items.find((i) => i.localId === localId);
+      if (!item) {
+        return;
+      }
       await deleteItemOp({
         listContext: { activeLocalId, activeServerId },
-        itemLocalId: localId,
+        item,
       });
       set({ items: items.filter((i) => i.localId !== localId) });
     },
@@ -306,16 +293,18 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       if (!activeLocalId) {
         return;
       }
-      await saveItemOp({
+      const item = items.find((i) => i.localId === localId);
+      if (!item) {
+        return;
+      }
+      const updated = await saveItemOp({
         listContext: { activeLocalId, activeServerId },
-        itemLocalId: localId,
+        item,
         name,
         description,
         iconKey,
       });
-      set({
-        items: items.map((i) => (i.localId === localId ? { ...i, name, description, iconKey } : i)),
-      });
+      set({ items: items.map((i) => (i.localId === localId ? updated : i)) });
     },
 
     addItem: async (name, description, iconKey, category) => {
@@ -370,29 +359,19 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
       if (!activeLocalId) {
         return;
       }
+      const item = items.find((i) => i.localId === localId);
+      if (!item) {
+        return;
+      }
       const category =
         categoryId !== null ? (allCategories.find((c) => c.id === categoryId) ?? null) : null;
 
-      await moveItemToCategoryOp({
+      const updated = await moveItemToCategoryOp({
         listContext: { activeLocalId, activeServerId },
-        itemLocalId: localId,
+        item,
         category,
       });
-
-      set({
-        items: items.map((i) =>
-          i.localId === localId
-            ? {
-                ...i,
-                category: category?.name ?? 'Uncategorized',
-                serverCategoryId: category?.id ?? null,
-                serverCategoryName: category?.name ?? null,
-                serverCategoryOrdering: category?.ordering ?? null,
-                isDirty: true,
-              }
-            : i
-        ),
-      });
+      set({ items: items.map((i) => (i.localId === localId ? updated : i)) });
     },
   };
 });

--- a/src/sync/syncManager.ts
+++ b/src/sync/syncManager.ts
@@ -123,7 +123,9 @@ async function dispatchPayload(api: ShoppingListsApi, payload: SyncPayload): Pro
   switch (payload.opType) {
     case 'ADD_ITEM': {
       const addItem = await getItem(payload.itemLocalId);
-      const addDescription = generateServerDescription(payload.description, addItem?.isImportant ?? false);
+      const addDescription = addItem
+        ? generateServerDescription({ ...addItem, description: payload.description })
+        : payload.description;
       const result = await api.addItemByName(payload.listServerId, payload.name, addDescription);
       await markItemSynced(
         payload.itemLocalId,
@@ -175,7 +177,9 @@ async function dispatchPayload(api: ShoppingListsApi, payload: SyncPayload): Pro
 
     case 'UPDATE_ITEM': {
       const updateItem = await getItem(payload.itemLocalId);
-      const updateDescription = generateServerDescription(payload.description, updateItem?.isImportant ?? false);
+      const updateDescription = updateItem
+        ? generateServerDescription({ ...updateItem, description: payload.description })
+        : payload.description;
       await api.updateItem(
         payload.itemServerId,
         payload.name,

--- a/src/sync/syncManager.ts
+++ b/src/sync/syncManager.ts
@@ -7,6 +7,7 @@ import {
 } from '@/db/syncQueue';
 import type { SyncOp, SyncPayload } from '@/db/syncQueue';
 import { getItem, markItemSynced, hardDeleteItem, markItemCheckSynced } from '@/db/items';
+import { generateServerDescription } from '@/utils/generateServerDescription';
 import { markListSynced, hardDeleteList } from '@/db/lists';
 import type { ShoppingListsApi } from '@/api/shoppinglists';
 import { useSyncStore } from '@/store/syncStore';
@@ -122,7 +123,7 @@ async function dispatchPayload(api: ShoppingListsApi, payload: SyncPayload): Pro
   switch (payload.opType) {
     case 'ADD_ITEM': {
       const addItem = await getItem(payload.itemLocalId);
-      const addDescription = addItem?.isImportant ? `!${payload.description}` : payload.description;
+      const addDescription = generateServerDescription(payload.description, addItem?.isImportant ?? false);
       const result = await api.addItemByName(payload.listServerId, payload.name, addDescription);
       await markItemSynced(
         payload.itemLocalId,
@@ -174,9 +175,7 @@ async function dispatchPayload(api: ShoppingListsApi, payload: SyncPayload): Pro
 
     case 'UPDATE_ITEM': {
       const updateItem = await getItem(payload.itemLocalId);
-      const updateDescription = updateItem?.isImportant
-        ? `!${payload.description}`
-        : payload.description;
+      const updateDescription = generateServerDescription(payload.description, updateItem?.isImportant ?? false);
       await api.updateItem(
         payload.itemServerId,
         payload.name,

--- a/src/utils/generateServerDescription.ts
+++ b/src/utils/generateServerDescription.ts
@@ -1,3 +1,5 @@
-export function generateServerDescription(description: string, isImportant: boolean): string {
-  return isImportant ? `!${description}` : description;
+import type { LocalItem } from '@/db/items';
+
+export function generateServerDescription(item: LocalItem): string {
+  return item.isImportant ? `!${item.description}` : item.description;
 }

--- a/src/utils/generateServerDescription.ts
+++ b/src/utils/generateServerDescription.ts
@@ -1,0 +1,3 @@
+export function generateServerDescription(description: string, isImportant: boolean): string {
+  return isImportant ? `!${description}` : description;
+}


### PR DESCRIPTION
Moves all item DB-write + sync-enqueue pairs out of listDetailStore into a dedicated src/items/itemOperations.ts module. Each exported function owns both sides of the pairing — it is no longer possible to write a new item action without the sync op being right there in the same function.

Changes:
- src/items/itemOperations.ts (new): addItem, checkItem, uncheckItem, toggleImportant, deleteItem, saveItem, moveItemToCategory — each handles the SQLite write and the sync enqueue as a unit
- src/store/listDetailStore.ts: actions collapse to ~5 lines each — read Zustand state, call the op, update Zustand state
- src/db/items.ts: fix toggleItemImportant to set is_dirty=1 so a crash between the DB write and the sync enqueue doesn't silently leave the importance flag out of sync
- src/__tests__/items/itemOperations.test.ts (new): 55 tests verifying each operation's DB call, sync payload, no-serverId skip, and ! prefix
- src/__tests__/store/listDetailStore.test.ts: mocks the ops module; store tests now verify Zustand state only (DB/sync covered by ops tests)

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh