### PR TITLE
Add Socket.IO support for real-time shopping list updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
+        "socket.io-client": "^4.8.3",
         "uuid": "^13.0.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
@@ -4218,6 +4219,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-native": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
@@ -6882,6 +6889,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -16659,6 +16709,34 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -18131,6 +18209,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "<rootDir>/jest.setup.ts"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@gorhom|@shopify|fuse\\.js|@ungap|uuid)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@gorhom|@shopify|fuse\\.js|@ungap|uuid|socket\\.io-client|engine\\.io-client|@socket\\.io)"
     ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1",
@@ -58,6 +58,7 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
+    "socket.io-client": "^4.8.3",
     "uuid": "^13.0.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/src/db/items.ts
+++ b/src/db/items.ts
@@ -246,6 +246,14 @@ export async function hardDeleteItem(localId: string): Promise<void> {
   await db.runAsync('DELETE FROM local_items WHERE local_id = ?', [localId]);
 }
 
+export async function removeItemByServerId(listLocalId: string, serverId: number): Promise<void> {
+  const db = await getDb();
+  await db.runAsync(
+    'DELETE FROM local_items WHERE list_local_id = ? AND server_id = ?',
+    [listLocalId, serverId]
+  );
+}
+
 /** Move an item into the trolley: marks it checked, dirty, and records when it was checked. */
 export async function checkItem(localId: string, checkedAt: number): Promise<void> {
   const db = await getDb();

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -9,6 +9,7 @@ import { initializeAuth } from '@/auth/authManager';
 import { getDb } from '@/db/schema';
 import { startNetworkMonitoring, stopNetworkMonitoring } from '@/sync/connectivityMonitor';
 import { drain } from '@/sync/syncManager';
+import { socketManager } from '@/socket/socketManager';
 
 import WelcomeScreen from '@/screens/auth/WelcomeScreen';
 import ServerSetupScreen from '@/screens/auth/ServerSetupScreen';
@@ -39,11 +40,13 @@ function MainNavigator() {
   const selectedHousehold = useHouseholdStore((s) => s.selectedHousehold);
 
   useEffect(() => {
-    startNetworkMonitoring(() => {
-      void drain();
-    });
+    void socketManager.connect();
+    startNetworkMonitoring(() => { void drain(); });
     void drain();
-    return () => stopNetworkMonitoring();
+    return () => {
+      socketManager.disconnect();
+      stopNetworkMonitoring();
+    };
   }, []);
 
   return (

--- a/src/socket/socketManager.ts
+++ b/src/socket/socketManager.ts
@@ -25,13 +25,13 @@ class SocketManager {
   private socket: Socket | null = null;
 
   async connect(): Promise<void> {
-    if (this.socket?.connected) return;
+    if (this.socket?.connected) {return;}
 
     const [serverUrl, tokens] = await Promise.all([
       TokenStore.instance.getServerUrl(),
       TokenStore.instance.getTokens(),
     ]);
-    if (!serverUrl || !tokens) return;
+    if (!serverUrl || !tokens) {return;}
 
     this.socket = io(serverUrl, {
       path: '/socket.io/',
@@ -57,7 +57,7 @@ class SocketManager {
 
   private async onItemAdd(payload: ShoppinglistEventPayload): Promise<void> {
     const { activeLocalId, activeServerId } = useListDetailStore.getState();
-    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) return;
+    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) {return;}
 
     const { item } = payload;
     const match = matchItem(item.icon ?? item.name);
@@ -77,7 +77,7 @@ class SocketManager {
 
   private async onItemRemove(payload: ShoppinglistEventPayload): Promise<void> {
     const { activeLocalId, activeServerId } = useListDetailStore.getState();
-    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) return;
+    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) {return;}
 
     await removeItemByServerId(activeLocalId, payload.item.id);
     await useListDetailStore.getState().reloadAfterSync();

--- a/src/socket/socketManager.ts
+++ b/src/socket/socketManager.ts
@@ -1,0 +1,87 @@
+import { io, Socket } from 'socket.io-client';
+import { TokenStore } from '@/auth/tokenStore';
+import { matchItem } from '@/data/foodMatcher';
+import { upsertItemFromServer, removeItemByServerId } from '@/db/items';
+import { useListDetailStore } from '@/store/listDetailStore';
+
+// ─── Payload types ────────────────────────────────────────────────────────────
+
+type SocketItem = {
+  id: number;
+  name: string;
+  description: string;
+  icon?: string | null;
+  category?: { id: number; name: string; ordering: number } | null;
+};
+
+type ShoppinglistEventPayload = {
+  item: SocketItem;
+  shoppinglist: { id: number };
+};
+
+// ─── SocketManager ────────────────────────────────────────────────────────────
+
+class SocketManager {
+  private socket: Socket | null = null;
+
+  async connect(): Promise<void> {
+    if (this.socket?.connected) return;
+
+    const [serverUrl, tokens] = await Promise.all([
+      TokenStore.instance.getServerUrl(),
+      TokenStore.instance.getTokens(),
+    ]);
+    if (!serverUrl || !tokens) return;
+
+    this.socket = io(serverUrl, {
+      path: '/socket.io/',
+      transports: ['polling', 'websocket'],
+      extraHeaders: {
+        Authorization: `Bearer ${tokens.accessToken}`,
+      },
+    });
+
+    this.socket.on('shoppinglist_item:add', (payload: ShoppinglistEventPayload) => {
+      void this.onItemAdd(payload);
+    });
+
+    this.socket.on('shoppinglist_item:remove', (payload: ShoppinglistEventPayload) => {
+      void this.onItemRemove(payload);
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+
+  private async onItemAdd(payload: ShoppinglistEventPayload): Promise<void> {
+    const { activeLocalId, activeServerId } = useListDetailStore.getState();
+    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) return;
+
+    const { item } = payload;
+    const match = matchItem(item.icon ?? item.name);
+    await upsertItemFromServer(
+      item.id,
+      activeLocalId,
+      item.name,
+      item.description ?? '',
+      match.iconKey,
+      match.category,
+      item.category?.id ?? null,
+      item.category?.name ?? null,
+      item.category?.ordering ?? null
+    );
+    await useListDetailStore.getState().reloadAfterSync();
+  }
+
+  private async onItemRemove(payload: ShoppinglistEventPayload): Promise<void> {
+    const { activeLocalId, activeServerId } = useListDetailStore.getState();
+    if (!activeLocalId || activeServerId !== payload.shoppinglist.id) return;
+
+    await removeItemByServerId(activeLocalId, payload.item.id);
+    await useListDetailStore.getState().reloadAfterSync();
+  }
+}
+
+export const socketManager = new SocketManager();

--- a/src/socket/socketManager.ts
+++ b/src/socket/socketManager.ts
@@ -60,7 +60,7 @@ class SocketManager {
     if (!activeLocalId || activeServerId !== payload.shoppinglist.id) {return;}
 
     const { item } = payload;
-    const match = matchItem(item.icon ?? item.name);
+    const match = matchItem(item.name);
     await upsertItemFromServer(
       item.id,
       activeLocalId,

--- a/src/socket/socketManager.ts
+++ b/src/socket/socketManager.ts
@@ -60,7 +60,10 @@ class SocketManager {
     if (!activeLocalId || activeServerId !== payload.shoppinglist.id) {return;}
 
     const { item } = payload;
-    const match = matchItem(item.name);
+    // Prefer the icon key over the name: the icon is a normalised food
+    // identifier (e.g. "milk_carton") that maps more reliably to a category
+    // than a free-text name that may be localised or user-entered.
+    const match = matchItem(item.icon ?? item.name);
     await upsertItemFromServer(
       item.id,
       activeLocalId,

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -123,7 +123,7 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
         return;
       }
       for (const apiItem of apiList.items) {
-        const match = matchItem(apiItem.icon ?? apiItem.name);
+        const match = matchItem(apiItem.name);
         await upsertItemFromServer(
           apiItem.id,
           localId,

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -123,7 +123,10 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
         return;
       }
       for (const apiItem of apiList.items) {
-        const match = matchItem(apiItem.name);
+        // Prefer the icon key over the name: the icon is a normalised food
+        // identifier (e.g. "milk_carton") that maps more reliably to a category
+        // than a free-text name that may be localised or user-entered.
+        const match = matchItem(apiItem.icon ?? apiItem.name);
         await upsertItemFromServer(
           apiItem.id,
           localId,


### PR DESCRIPTION
Installs socket.io-client v4 (matches python-socketio 5.x / EIO=4).

socketManager connects on MainNavigator mount using polling→websocket transport with a Bearer token Authorization header. It listens for shoppinglist_item:add and shoppinglist_item:remove events and, when the event targets the currently active list, upserts/hard-deletes the item in SQLite then calls reloadAfterSync() to update the UI.

Also adds removeItemByServerId to db/items for targeted socket removes.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh