### PR TITLE
Enlarge list selector chevron; replace camera icon with disabled add …

### DIFF
--- a/src/__tests__/components/AddItemBar.test.tsx
+++ b/src/__tests__/components/AddItemBar.test.tsx
@@ -44,11 +44,11 @@ beforeEach(() => {
 
 describe('AddItemBar', () => {
   describe('add-as-typed row', () => {
-    it('shows the typed row when there are no suggestions', () => {
+    it('submit button is disabled when input is empty', () => {
       const onAdd = jest.fn();
-      const { queryByText } = render(<AddItemBar onAdd={onAdd} />);
-      // No input yet — suggestions panel is hidden entirely
-      expect(queryByText('+')).toBeNull();
+      const { getByTestId } = render(<AddItemBar onAdd={onAdd} />);
+      // No input yet — button is present but disabled
+      expect(getByTestId('add-item-submit').props.accessibilityState?.disabled).toBe(true);
     });
 
     it('shows the typed row when no suggestion exactly matches the input', () => {

--- a/src/components/AddItemBar.tsx
+++ b/src/components/AddItemBar.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import KitchenOwlIcon from '@/components/KitchenOwlIcon';
-import CameraIcon from '@/components/icons/CameraIcon';
 import { useItemSuggestions } from '@/hooks/useItemSuggestions';
 import { useHouseholdStore } from '@/store/householdStore';
 import { useAuthStore } from '@/store/authStore';
@@ -101,6 +100,7 @@ export default function AddItemBar({ onAdd }: AddItemBarProps) {
     commit(s.displayName, description, s.iconKey, s.category);
   }
 
+  const canAdd = trimmedValue.length > 0;
   const busy = parsing;
 
   return (
@@ -120,18 +120,16 @@ export default function AddItemBar({ onAdd }: AddItemBarProps) {
           testID="add-item-input"
         />
         <TouchableOpacity
-          style={[styles.addBtn, busy && styles.addBtnBusy]}
+          style={[styles.addBtn, (!canAdd || busy) && styles.addBtnDisabled]}
           onPress={handleAdd}
           activeOpacity={0.85}
-          disabled={busy}
+          disabled={!canAdd || busy}
           testID="add-item-submit"
         >
           {busy ? (
             <ActivityIndicator size="small" color={Colors.white} />
-          ) : value.trim() ? (
-            <Text style={styles.addBtnPlus}>+</Text>
           ) : (
-            <CameraIcon size={20} color={Colors.white} />
+            <Text style={styles.addBtnPlus}>+</Text>
           )}
         </TouchableOpacity>
       </View>
@@ -229,8 +227,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  addBtnBusy: {
-    opacity: 0.6,
+  addBtnDisabled: {
+    opacity: 0.35,
   },
   addBtnPlus: {
     color: Colors.white,

--- a/src/screens/lists/ListDetailScreen.tsx
+++ b/src/screens/lists/ListDetailScreen.tsx
@@ -428,7 +428,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   chevron: {
-    fontSize: FontSize.heading,
+    fontSize: 26,
     color: Colors.mint,
     marginTop: 2,
   },


### PR DESCRIPTION
…button

- ListDetailScreen: chevron fontSize 17 → 26
- AddItemBar: remove CameraIcon; always show + button, disabled (opacity 0.35) when input is empty, enabled as soon as the user types anything

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh