### PR TITLE
Fix list selection not resetting when switching households

### DIFF
--- a/src/__tests__/store/listDetailStore.test.ts
+++ b/src/__tests__/store/listDetailStore.test.ts
@@ -279,6 +279,27 @@ describe('bootstrap', () => {
     expect(getItemsForList).not.toHaveBeenCalled();
   });
 
+  it('does a full bootstrap when the household changes (household switch)', async () => {
+    const oldList = makeList({ localId: 'list-local-1', householdId: 1 });
+    const newList = makeList({ localId: 'list-local-2', householdId: 2, serverId: 9, name: 'New HH Groceries' });
+    useListDetailStore.setState({
+      activeLocalId: 'list-local-1',
+      activeServerId: 5,
+      items: [makeItem()],
+      allLists: [oldList],
+      loading: false,
+    });
+    (getAllLists as jest.Mock).mockResolvedValue([newList]);
+    (getItemsForList as jest.Mock).mockResolvedValue([]);
+
+    // Bootstrap with a different householdId — should not reuse the old list
+    await useListDetailStore.getState().bootstrap(2, false);
+
+    expect(useListDetailStore.getState().activeLocalId).toBe('list-local-2');
+    expect(useListDetailStore.getState().activeName).toBe('New HH Groceries');
+    expect(getItemsForList).toHaveBeenCalledWith('list-local-2');
+  });
+
   it('does a full bootstrap when the active list was deleted', async () => {
     const remainingList = makeList({ localId: 'list-2', name: 'Pharmacy', serverId: 8 });
     // activeLocalId set, but deleted list is absent from allLists

--- a/src/store/listDetailStore.ts
+++ b/src/store/listDetailStore.ts
@@ -187,7 +187,9 @@ export const useListDetailStore = create<ListDetailState>((set, get) => {
 
     bootstrap: async (householdId, restoreLastList) => {
       const { activeLocalId, activeServerId, allLists } = get();
-      const activeListStillExists = activeLocalId != null && allLists.some((l) => l.localId === activeLocalId);
+      const activeListStillExists =
+        activeLocalId != null &&
+        allLists.some((l) => l.localId === activeLocalId && l.householdId === householdId);
       if (activeListStillExists) {
         // Already loaded — refresh in background without disrupting the UI.
         void get().syncLists(householdId);


### PR DESCRIPTION
bootstrap() was short-circuiting if any active list existed in allLists, but allLists still held the previous household's lists after a switch. Fix: include householdId in the existence check so a list from the wrong household is not treated as already loaded. Add a regression test.

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh