### PR TITLE
Improve startup error handling — DB reset + Keystore recovery

### DIFF
--- a/src/__tests__/auth/authManager.test.ts
+++ b/src/__tests__/auth/authManager.test.ts
@@ -115,4 +115,27 @@ describe('initializeAuth', () => {
     expect(setAuthenticated).toHaveBeenCalledWith(null, SERVER_URL);
     expect(setUnauthenticated).not.toHaveBeenCalled();
   });
+
+  it('sets unauthenticated when the Keystore/Keychain throws (e.g. Android PIN change)', async () => {
+    (mockTokenStore.getServerUrl as jest.Mock).mockRejectedValue(
+      new Error('KeyStoreException: key not found')
+    );
+
+    await initializeAuth();
+
+    expect(setUnauthenticated).toHaveBeenCalled();
+    expect(setAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('sets unauthenticated when getTokens throws after a successful getServerUrl', async () => {
+    (mockTokenStore.getServerUrl as jest.Mock).mockResolvedValue(SERVER_URL);
+    (mockTokenStore.getTokens as jest.Mock).mockRejectedValue(
+      new Error('KeyStoreException: key not found')
+    );
+
+    await initializeAuth();
+
+    expect(setUnauthenticated).toHaveBeenCalled();
+    expect(setAuthenticated).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/navigation/RootNavigator.test.tsx
+++ b/src/__tests__/navigation/RootNavigator.test.tsx
@@ -9,6 +9,7 @@ jest.mock('@/auth/authManager', () => ({
 
 jest.mock('@/db/schema', () => ({
   getDb: jest.fn().mockResolvedValue({}),
+  resetDb: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@/sync/syncManager', () => ({
@@ -147,6 +148,7 @@ import RootNavigator from '@/navigation/RootNavigator';
 import { useAuthStore } from '@/store/authStore';
 import { useHouseholdStore } from '@/store/householdStore';
 import { initializeAuth } from '@/auth/authManager';
+import { getDb, resetDb } from '@/db/schema';
 
 type AuthState = { status: 'unknown' | 'unauthenticated' | 'authenticated' };
 type HouseholdState = { selectedHousehold: { id: number; name: string; photo: null } | null };
@@ -198,5 +200,38 @@ describe('RootNavigator', () => {
     mockAuth('unauthenticated');
     render(<RootNavigator />);
     await waitFor(() => expect(initializeAuth).toHaveBeenCalled());
+  });
+
+  describe('startup error handling', () => {
+    it('resets and retries when getDb fails the first time', async () => {
+      mockAuth('unauthenticated');
+      (getDb as jest.Mock)
+        .mockRejectedValueOnce(new Error('db open failed'))
+        .mockResolvedValueOnce({});
+
+      const { getByText } = render(<RootNavigator />);
+      await waitFor(() => expect(resetDb).toHaveBeenCalled());
+      await waitFor(() => expect(getByText('ServerSetup')).toBeTruthy());
+    });
+
+    it('shows fatal error screen when db reset also fails', async () => {
+      mockAuth('unknown');
+      (getDb as jest.Mock).mockRejectedValue(new Error('db open failed'));
+      (resetDb as jest.Mock).mockRejectedValue(new Error('delete failed'));
+
+      const { getByText } = render(<RootNavigator />);
+      await waitFor(() => expect(getByText('Unable to open storage')).toBeTruthy());
+    });
+
+    it('does not freeze when initializeAuth throws an unexpected error', async () => {
+      // initializeAuth handles Keystore errors itself; this covers any remaining
+      // edge case where it unexpectedly throws.
+      (initializeAuth as jest.Mock).mockRejectedValueOnce(new Error('unexpected'));
+      mockAuth('unauthenticated');
+
+      const { getByText } = render(<RootNavigator />);
+      // App should render the auth screen rather than freezing on the splash
+      await waitFor(() => expect(getByText('ServerSetup')).toBeTruthy());
+    });
   });
 });

--- a/src/auth/authManager.ts
+++ b/src/auth/authManager.ts
@@ -9,7 +9,7 @@ import { ApiClientManager } from '@/api/client';
 import { AuthApi } from '@/api/auth';
 import { HouseholdsApi } from '@/api/households';
 import { ShoppingListsApi } from '@/api/shoppinglists';
-import { TokenStore } from '@/auth/tokenStore';
+import { TokenStore, type StoredTokens } from '@/auth/tokenStore';
 import { useAuthStore } from '@/store/authStore';
 import { restoreSelectedHousehold } from '@/store/householdStore';
 
@@ -34,21 +34,25 @@ function createApis(serverUrl: string): AuthApi {
 }
 
 export async function initializeAuth(): Promise<void> {
-  const serverUrl = await TokenStore.instance.getServerUrl();
-  if (!serverUrl) {
+  let serverUrl: string | null;
+  let tokens: StoredTokens | null;
+  try {
+    serverUrl = await TokenStore.instance.getServerUrl();
+    tokens = serverUrl ? await TokenStore.instance.getTokens() : null;
+  } catch {
+    // Android Keystore or iOS Keychain can become unavailable after security
+    // setting changes (new PIN, biometric enrolment, some OEM OS updates).
+    // Fall through to unauthenticated so the user can log in again.
     useAuthStore.getState().setUnauthenticated();
     return;
   }
 
-  const tokens = await TokenStore.instance.getTokens();
-  if (!tokens) {
+  if (!serverUrl || !tokens) {
     useAuthStore.getState().setUnauthenticated();
     return;
   }
 
-  // User data is best-effort — a schema mismatch from an older install returns null,
-  // but that's fine. The interceptor will get fresh user data on the first API call
-  // if needed, and the token chain handles re-authentication transparently.
+  // User data is best-effort — a schema mismatch from an older install returns null.
   const user = await TokenStore.instance.getUser();
 
   useAuthStore.getState().setServerUrl(serverUrl);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,18 @@
-import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
+import { openDatabaseAsync, deleteDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
 
 // Promise-cache: a single in-flight open+migrate is shared across all callers,
 // preventing duplicate opens if getDb() is called concurrently before the DB is ready.
 let dbPromise: Promise<SQLiteDatabase> | null = null;
+
+/**
+ * Deletes the database file and clears the promise cache so the next
+ * getDb() call starts completely fresh. Used as a last-resort recovery
+ * when the initial open or migration fails.
+ */
+export async function resetDb(): Promise<void> {
+  dbPromise = null;
+  await deleteDatabaseAsync('towl.db');
+}
 
 export function getDb(): Promise<SQLiteDatabase> {
   dbPromise ??= openDatabaseAsync('towl.db').then(async (instance) => {

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { useAuthStore } from '@/store/authStore';
 import { useHouseholdStore } from '@/store/householdStore';
 import { initializeAuth } from '@/auth/authManager';
-import { getDb } from '@/db/schema';
+import { getDb, resetDb } from '@/db/schema';
 import { startNetworkMonitoring, stopNetworkMonitoring } from '@/sync/connectivityMonitor';
 import { drain } from '@/sync/syncManager';
 import { socketManager } from '@/socket/socketManager';
@@ -87,10 +87,44 @@ export default function RootNavigator() {
   const status = useAuthStore((s) => s.status);
   const selectedHousehold = useHouseholdStore((s) => s.selectedHousehold);
   const [routeName, setRouteName] = useState<string | undefined>();
+  const [dbError, setDbError] = useState(false);
 
   useEffect(() => {
-    getDb().then(initializeAuth).catch(console.error);
+    async function startup() {
+      // Open (and if necessary migrate) the database.
+      try {
+        await getDb();
+      } catch {
+        // First attempt failed — wipe the database and try once more.
+        // All data syncs from the server so a fresh DB is recoverable.
+        try {
+          await resetDb();
+          await getDb();
+        } catch {
+          setDbError(true);
+          return;
+        }
+      }
+
+      // Restore auth state from SecureStore — no network calls.
+      // initializeAuth handles Keystore errors internally; catch here is a
+      // last-resort safety net for truly unexpected failures.
+      await initializeAuth().catch(console.error);
+    }
+
+    void startup();
   }, []);
+
+  if (dbError) {
+    return (
+      <View style={styles.splash}>
+        <Text style={styles.errorTitle}>Unable to open storage</Text>
+        <Text style={styles.errorBody}>
+          Towl could not open its local database. Please uninstall and reinstall the app.
+        </Text>
+      </View>
+    );
+  }
 
   const showNav =
     status === 'authenticated' &&
@@ -129,5 +163,20 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: 32,
+    gap: 12,
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1a1a1a',
+    textAlign: 'center',
+  },
+  errorBody: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#666',
+    textAlign: 'center',
+    lineHeight: 22,
   },
 });


### PR DESCRIPTION
getDb() failure: attempt to wipe and recreate the database (all data syncs from server so a fresh DB is recoverable). If the second attempt also fails, show a fatal error screen asking the user to reinstall.

initializeAuth() Keystore failure: Android Keystore (and occasionally iOS Keychain) can become unavailable after security setting changes. Previously this left the app frozen on the splash spinner. Now the error is caught inside initializeAuth itself and falls through to unauthenticated so the user can log in again.

RootNavigator startup is now a clean async function with explicit error handling rather than a chained .then().catch(console.error).

https://claude.ai/code/session_01NB7JGqTZrEcYEz4PbWejRh